### PR TITLE
fix: improve date-time formatting, reset list pagination on filter ch…

### DIFF
--- a/src/components/core/form/fields/SolidDateTimeField.tsx
+++ b/src/components/core/form/fields/SolidDateTimeField.tsx
@@ -10,6 +10,7 @@ import { SolidFormFieldWidgetProps } from "../../../../types/solid-core";
 import { SolidFieldTooltip } from "../../../../components/common/SolidFieldTooltip";
 import { ERROR_MESSAGES } from "../../../../constants/error-messages";
 import { DateFieldViewComponent } from '../../../../components/core/common/DateFieldViewComponent';
+import dayjs from "dayjs";
 import styles from "./solidFields.module.css";
 
 const toDateValue = (value: any) => {
@@ -28,7 +29,9 @@ export class SolidDateTimeField implements ISolidField {
 
     updateFormData(value: any, formData: FormData): any {
         const fieldLayoutInfo = this.fieldContext.field;
-        if (value) {
+        if (value instanceof Date && !isNaN(value.getTime())) {
+            formData.append(fieldLayoutInfo.attrs.name, dayjs(value).format('YYYY-MM-DD HH:mm:ss'));
+        } else if (value) {
             formData.append(fieldLayoutInfo.attrs.name, value);
         }
     }

--- a/src/components/core/form/fields/SolidDateTimeField.tsx
+++ b/src/components/core/form/fields/SolidDateTimeField.tsx
@@ -12,6 +12,9 @@ import { ERROR_MESSAGES } from "../../../../constants/error-messages";
 import { DateFieldViewComponent } from '../../../../components/core/common/DateFieldViewComponent';
 import dayjs from "dayjs";
 import styles from "./solidFields.module.css";
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
 
 const toDateValue = (value: any) => {
     if (!value) return null;
@@ -30,7 +33,7 @@ export class SolidDateTimeField implements ISolidField {
     updateFormData(value: any, formData: FormData): any {
         const fieldLayoutInfo = this.fieldContext.field;
         if (value instanceof Date && !isNaN(value.getTime())) {
-            formData.append(fieldLayoutInfo.attrs.name, dayjs(value).format('YYYY-MM-DD HH:mm:ss'));
+            formData.append(fieldLayoutInfo.attrs.name, dayjs(value).utc().format('YYYY-MM-DD HH:mm:ss'));
         } else if (value) {
             formData.append(fieldLayoutInfo.attrs.name, value);
         }

--- a/src/components/core/list/SolidListView.tsx
+++ b/src/components/core/list/SolidListView.tsx
@@ -861,6 +861,7 @@ export const SolidListView = forwardRef<SolidListViewHandle, SolidListViewParams
     // Then update state
     setFilters(updatedFilter);
     setFilterPredicates(updatedFilterPredicates);
+    setFirst(0);
     // Force synchronous state updates
   };
 

--- a/src/components/shad-cn-ui/SolidDatePicker.tsx
+++ b/src/components/shad-cn-ui/SolidDatePicker.tsx
@@ -20,12 +20,23 @@ function formatDateValue(value: Date | null | undefined, pattern?: string) {
     return value.toISOString();
   }
   const pad = (num: number, length = 2) => String(num).padStart(length, "0");
+  const hours = value.getHours();
+  const minutes = value.getMinutes();
+  const seconds = value.getSeconds();
+  const ampm = hours >= 12 ? "PM" : "AM";
+  const h12 = hours % 12 || 12;
+
   return pattern
     .replace(/yyyy/g, String(value.getFullYear()))
     .replace(/MM/g, pad(value.getMonth() + 1))
     .replace(/dd/g, pad(value.getDate()))
-    .replace(/HH/g, pad(value.getHours()))
-    .replace(/mm/g, pad(value.getMinutes()));
+    .replace(/HH/g, pad(hours))
+    .replace(/hh/g, pad(h12))
+    .replace(/h/g, String(h12))
+    .replace(/mm/g, pad(minutes))
+    .replace(/ss/g, pad(seconds))
+    .replace(/aa/g, ampm)
+    .replace(/a/g, ampm);
 }
 
 const SolidDatePickerInput = React.forwardRef<HTMLInputElement, SolidDatePickerInputProps>(

--- a/src/components/shad-cn-ui/SolidTabs.tsx
+++ b/src/components/shad-cn-ui/SolidTabs.tsx
@@ -58,6 +58,7 @@ export function SolidTabGroup({
                   className={cx(
                     "solid-notebook-tab-trigger",
                     "solid-tabs-trigger",
+                    "w-full",
                     tab.hasError && "error",
                     isActive && "active",
                     isActive && "is-active",
@@ -83,6 +84,7 @@ export function SolidTabGroup({
                 className={cx(
                   "solid-notebook-tab-trigger",
                   "solid-tabs-trigger",
+                  "w-full",
                   tab.hasError && "error",
                   isActive && "active",
                   isActive && "is-active",

--- a/src/resources/shadcn-base.css
+++ b/src/resources/shadcn-base.css
@@ -6350,5 +6350,5 @@ html.dark .solid-paginator-btn:hover:not(:disabled),
 }
 
 .solid-list-toolbar-row{
-  padding: 5px 10px 0 10px;
+  padding: 5px 15px 0 10px;
 }

--- a/src/resources/shadcn-base.css
+++ b/src/resources/shadcn-base.css
@@ -1467,7 +1467,6 @@ body {
 }
 
 .solid-autocomplete-chip-label {
-  max-width: 130px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
Changes Made
1. Date-Time Formatting Improvements
Component: 
SolidDatePicker.tsx
Fix: Expanded the 
formatDateValue
 function to support more tokens:
hh / h: 12-hour format support.
ss: Seconds support.
aa / a: AM/PM support.
Result: Fixes the "h:30:aa" literal rendering issue when 12-hour format is selected.
2. Payload and Validation Fixes
Component: 
SolidDateTimeField.tsx
Fix: Ensured that the onChange handler converts the selected date to a proper UTC ISO string before passing it to Formik.
Component: 
SolidVarInputsFilterElement.tsx
Fix: Improved date normalization for filter inputs to handle ISO strings with 'Z' suffix correctly.
Result: Resolves "Invalid Format" and "Field is not a date" errors during save.
3. List Pagination Reset
Logic: Added a mechanism to reset the list to the first page whenever filters are updated.
Result: Prevents "no data" states when a filter restricts the result set while on a high page number.
4. UI Polish
CSS: Removed the max-width: 130px constraint on autocomplete chips in 
shadcn-base.css
.
Result: Better readability for long selection items.