### PR TITLE
Scheduled frequency

### DIFF
--- a/src/components/core/extension/solid-core/scheduled-job/scheduleFrequencyOnFieldChangeHandler.ts
+++ b/src/components/core/extension/solid-core/scheduled-job/scheduleFrequencyOnFieldChangeHandler.ts
@@ -11,9 +11,8 @@ export const scheduleFrequencyOnFieldChangeHandler = async (event: SolidUiEvent)
 
         // Reset all
         layoutManager.updateNodeAttributes('dayOfMonth', { visible: false });
-        layoutManager.updateNodeAttributes('dayOfWeek', { visible: false });
+        layoutManager.updateNodeAttributes('dayOfWeek', { visible: false, multiSelect: true });
         layoutManager.updateNodeAttributes('cronExpression', { visible: false });
-
         switch (value) {
 
             case 'custom':
@@ -25,7 +24,7 @@ export const scheduleFrequencyOnFieldChangeHandler = async (event: SolidUiEvent)
                 break;
 
             case 'weekly':
-                layoutManager.updateNodeAttributes('dayOfWeek', { visible: true });
+                layoutManager.updateNodeAttributes('dayOfWeek', { visible: true, multiSelect: false });
                 break;
 
             case 'monthly':

--- a/src/components/core/extension/solid-core/scheduled-job/scheduleFrequencyOnFieldChangeHandler.ts
+++ b/src/components/core/extension/solid-core/scheduled-job/scheduleFrequencyOnFieldChangeHandler.ts
@@ -1,0 +1,46 @@
+import { SolidViewLayoutManager } from "@/components/core/common/SolidViewLayoutManager";
+import { SolidUiEvent } from "@/types";
+
+export const scheduleFrequencyOnFieldChangeHandler = async (event: SolidUiEvent) => {
+    const { modifiedField, modifiedFieldValue, formViewLayout } = event;
+
+    const layoutManager = new SolidViewLayoutManager(formViewLayout);
+    const value = modifiedFieldValue?.value?.toLowerCase();
+
+    if (modifiedField === 'frequency') {
+
+        // Reset all
+        layoutManager.updateNodeAttributes('dayOfMonth', { visible: false });
+        layoutManager.updateNodeAttributes('dayOfWeek', { visible: false });
+        layoutManager.updateNodeAttributes('cronExpression', { visible: false });
+
+        switch (value) {
+
+            case 'custom':
+                layoutManager.updateNodeAttributes('cronExpression', { visible: true });
+                break;
+
+            case 'daily':
+                // No extra fields needed
+                break;
+
+            case 'weekly':
+                layoutManager.updateNodeAttributes('dayOfWeek', { visible: true });
+                break;
+
+            case 'monthly':
+                layoutManager.updateNodeAttributes('dayOfMonth', { visible: true });
+                break;
+
+            case 'hourly':
+            case 'every minute':
+                break;
+        }
+    }
+
+    return {
+        layoutChanged: true,
+        dataChanged: false,
+        newLayout: layoutManager.getLayout(),
+    };
+};

--- a/src/components/core/form/fields/SolidSelectionDynamicField.tsx
+++ b/src/components/core/form/fields/SolidSelectionDynamicField.tsx
@@ -27,9 +27,10 @@ export class SolidSelectionDynamicField implements ISolidField {
     initialValue(): any {
         // TODO: Use the field metadata to re-create the object in the valid format 
         // {label: '', value: ''}
-        const optionValue = this.fieldContext.data[this.fieldContext.field.attrs.name];
+        const fieldLayoutInfo = this.fieldContext.field;
+        const optionValue = this.fieldContext.data[fieldLayoutInfo.attrs.name];
         const fieldMetadata = this.fieldContext.fieldMetadata;
-        const isMultiSelect = fieldMetadata?.isMultiSelect;
+        const isMultiSelect = fieldLayoutInfo.attrs.multiSelect ?? fieldMetadata?.isMultiSelect;
         // isMultiSelect: fieldMetaData ? fieldMetaData?.isMultiSelect : false,
 
         // return { label: optionValue || '', value: optionValue || '' };
@@ -49,6 +50,10 @@ export class SolidSelectionDynamicField implements ISolidField {
                 return { label: strVal, value: strVal };
             }
         };
+
+        if (optionValue === '' || optionValue === null || optionValue === undefined || (Array.isArray(optionValue) && optionValue.length === 0)) {
+            return null;
+        }
 
         if (isMultiSelect) {
             if (Array.isArray(optionValue)) {
@@ -74,7 +79,7 @@ export class SolidSelectionDynamicField implements ISolidField {
     updateFormData(value: any, formData: FormData): any {
         const fieldLayoutInfo = this.fieldContext.field;
         const fieldMetadata = this.fieldContext.fieldMetadata;
-        const isMultiSelect = fieldMetadata?.isMultiSelect;
+        const isMultiSelect = fieldLayoutInfo.attrs.multiSelect ?? fieldMetadata?.isMultiSelect;
         const stripQuotes = (str: string) => str.replace(/^"+|"+$/g, '').replace(/^'+|'+$/g, '');
 
         if (value) {
@@ -108,7 +113,7 @@ export class SolidSelectionDynamicField implements ISolidField {
         // }
 
         // return schema;
-        const isMultiSelect = fieldMetadata?.isMultiSelect;
+        const isMultiSelect = fieldLayoutInfo.attrs.multiSelect ?? fieldMetadata?.isMultiSelect;
 
 
         const isRequired = fieldLayoutInfo.attrs?.required ?? fieldMetadata.required;
@@ -198,7 +203,7 @@ export const DefaultSelectionDynamicFormEditWidget = ({ formik, fieldContext }: 
     const formReadonly = solidFormViewMetaData.data.solidView?.layout?.attrs?.readonly;
     const whereClause = fieldLayoutInfo.attrs.whereClause;
 
-    const isMultiSelect = fieldMetadata?.isMultiSelect;
+    const isMultiSelect = fieldLayoutInfo.attrs.multiSelect ?? fieldMetadata?.isMultiSelect;
 
     // selection dynamic specific code. 
     const [triggerGetSelectionDynamicValues] = useLazyGetSelectionDynamicValuesQuery();
@@ -292,7 +297,7 @@ export const DefaultSelectionDynamicFormViewWidget = ({ formik, fieldContext }: 
     const fieldLabel = fieldLayoutInfo.attrs.label ?? fieldMetadata.displayName;
     const showFieldLabel = fieldLayoutInfo?.attrs?.showLabel;
     const value = formik.values[fieldLayoutInfo.attrs.name];
-    const isMultiSelect = fieldMetadata?.isMultiSelect;
+    const isMultiSelect = fieldLayoutInfo.attrs.multiSelect ?? fieldMetadata?.isMultiSelect;
 
     const toLabel = (val: any) => {
         if (!val) return '';

--- a/src/components/core/form/fields/SolidSelectionStaticField.tsx
+++ b/src/components/core/form/fields/SolidSelectionStaticField.tsx
@@ -25,7 +25,7 @@ export class SolidSelectionStaticField implements ISolidField {
     updateFormData(value: any, formData: FormData): any {
         const fieldLayoutInfo = this.fieldContext.field;
         const fieldMetadata = this.fieldContext.fieldMetadata;
-        const isMultiSelect = fieldMetadata?.isMultiSelect;
+        const isMultiSelect = fieldLayoutInfo.attrs.multiSelect ?? fieldMetadata?.isMultiSelect;
         if (isMultiSelect && Array.isArray(value)) {
             formData.append(fieldLayoutInfo.attrs.name, JSON.stringify(value.map(v => v.value)));
         } else if (value) {
@@ -38,10 +38,11 @@ export class SolidSelectionStaticField implements ISolidField {
 
     initialValue(): any {
         // Get field name and metadata
-        const fieldName = this.fieldContext.field.attrs.name;
+        const fieldLayoutInfo = this.fieldContext.field;
+        const fieldName = fieldLayoutInfo.attrs.name;
         const fieldMetadata = this.fieldContext.fieldMetadata;
         const fieldDefaultValue = fieldMetadata?.defaultValue;
-        const isMultiSelect = fieldMetadata?.isMultiSelect;
+        const isMultiSelect = fieldLayoutInfo.attrs.multiSelect ?? fieldMetadata?.isMultiSelect;
         // Get existing value from form data
         const existingValue = this.fieldContext.data[fieldName];
 
@@ -65,6 +66,10 @@ export class SolidSelectionStaticField implements ISolidField {
 
         // Determine the final value to use (existing value or default value)
         const finalValue = existingValue ?? fieldDefaultValue ?? '';
+
+        if (finalValue === '' || finalValue === null || finalValue === undefined || (Array.isArray(finalValue) && finalValue.length === 0)) {
+            return null;
+        }
 
         if (isMultiSelect) {
             let values: string[] = [];
@@ -96,7 +101,7 @@ export class SolidSelectionStaticField implements ISolidField {
         const fieldMetadata = this.fieldContext.fieldMetadata;
         const fieldLayoutInfo = this.fieldContext.field;
         const fieldLabel = fieldLayoutInfo.attrs.label ?? fieldMetadata.displayName;
-        const isMultiSelect = fieldMetadata?.isMultiSelect;
+        const isMultiSelect = fieldLayoutInfo.attrs.multiSelect ?? fieldMetadata?.isMultiSelect;
 
         // let schema = Yup.object({
         //     value: Yup.string().required(`${fieldLabel} is required.`)
@@ -195,7 +200,7 @@ export const DefaultSelectionStaticAutocompleteFormEditWidget = ({ formik, field
 
         const formDisabled = solidFormViewMetaData.data.solidView?.layout?.attrs?.disabled;
         const formReadonly = solidFormViewMetaData.data.solidView?.layout?.attrs?.readonly;
-        const isMultiSelect = fieldMetadata?.isMultiSelect;
+        const isMultiSelect = fieldLayoutInfo.attrs.multiSelect ?? fieldMetadata?.isMultiSelect;
 
     const [selectionStaticItems, setSelectionStaticItems] = useState([]);
     const selectionStaticSearch = (event: AutoCompleteCompleteEvent) => {
@@ -261,7 +266,7 @@ export const SolidSelectionStaticRadioFormEditWidget = ({ formik, fieldContext }
     const formReadonly = fieldContext.solidFormViewMetaData.data.solidView?.layout?.attrs?.readonly;
 
     const fieldName = fieldLayoutInfo.attrs.name;
-    const isMultiSelect = fieldMetadata?.isMultiSelect;
+    const isMultiSelect = fieldLayoutInfo.attrs.multiSelect ?? fieldMetadata?.isMultiSelect;
     // Convert selectionStaticValues to usable radio options
     const radioOptions = fieldMetadata.selectionStaticValues.map((i: string) => {
         const [value, label] = i.split(":");
@@ -320,7 +325,7 @@ export const SolidSelectionStaticSelectButtonFormEditWidget = ({ formik, fieldCo
     const formReadonly = fieldContext.solidFormViewMetaData.data.solidView?.layout?.attrs?.readonly;
 
     const fieldName = fieldLayoutInfo.attrs.name;
-    const isMultiSelect = fieldMetadata?.isMultiSelect;
+    const isMultiSelect = fieldLayoutInfo.attrs.multiSelect ?? fieldMetadata?.isMultiSelect;
 
     const isFormFieldValid = (formik: any, fieldName: string) =>
         formik.errors[fieldName];
@@ -375,7 +380,7 @@ export const DefaultSelectionStaticFormViewWidget = ({ formik, fieldContext }: S
     const fieldLayoutInfo = fieldContext.field;
     const fieldLabel = fieldLayoutInfo.attrs.label ?? fieldMetadata.displayName;
     const value = formik.values[fieldLayoutInfo.attrs.name];
-    const isMultiSelect = fieldMetadata?.isMultiSelect;
+    const isMultiSelect = fieldLayoutInfo.attrs.multiSelect ?? fieldMetadata?.isMultiSelect;
     const showFieldLabel = fieldLayoutInfo?.attrs?.showLabel;
     return (
         <div className={styles.fieldViewWrapper}>

--- a/src/helpers/registry.ts
+++ b/src/helpers/registry.ts
@@ -67,6 +67,8 @@ import {
     type ExtensionFunctionType,
 } from "../types/extension-registry";
 
+import { scheduleFrequencyOnFieldChangeHandler } from "@/components/core/extension/solid-core/scheduled-job/scheduleFrequencyOnFieldChangeHandler";
+
 
 type ExtensionComponentMetadata = {
     component: React.ComponentType<any>;
@@ -389,3 +391,6 @@ registerExtensionFunction("dashboardQuestionOnFormLoadHandler", dashboardQuestio
 // on change of model, apply a where clause on the field field...
 registerExtensionFunction("modelSequenceFormViewChangeHandler", hanldeModelSequenceFormViewChange, ExtensionFunctionTypes.onFieldChange);
 registerExtensionFunction("mqMessageOnFormLoadHandler", mqMessageOnFormLoadHandler, ExtensionFunctionTypes.onFormLoad);
+
+
+registerExtensionFunction("scheduleFrequencyOnFieldChangeHandler", scheduleFrequencyOnFieldChangeHandler, ExtensionFunctionTypes.onFieldChange);

--- a/src/types/solid-core.d.ts
+++ b/src/types/solid-core.d.ts
@@ -100,6 +100,7 @@ export type LayoutAttribute = {
     editAction?: any;
     createAction?: any;
     required?: boolean;
+    multiSelect?: boolean;
 };
 
 // Generic representation of any node in our layout 


### PR DESCRIPTION
feat: add multiSelect attr support and schedule frequency field visibility handling

- Added support for `multiSelect` prop in `attrs` to enable handling through extension functions and layout managers.
- Introduced `scheduleFrequencyOnFieldChangeHandler` for dynamic show/hide field logic in Scheduled Job form view.

Field visibility rules:
- `custom`:
  - Hide Day of Month
  - Hide Day of Week

- `daily`:
  - Hide Cron Expression
  - Hide Day of Month

- `weekly`:
  - Show Day of Week with single-select only
  - Hide Cron Expression
  - Hide Day of Month

- `monthly`:
  - Hide Day of Week
  - Hide Cron Expression