### PR TITLE
Fix popover alignment by setting left property to auto

### DIFF
--- a/src/resources/shadcn-base.css
+++ b/src/resources/shadcn-base.css
@@ -4149,7 +4149,7 @@ html.dark .solid-paginator-btn:hover:not(:disabled),
 
 .solid-popover-content[data-side="bottom"][data-align="end"] {
   right: 0;
-  left: 0;
+  left: auto;
 }
 
 .solid-popover-content[data-side="top"] {


### PR DESCRIPTION
Fix popover alignment by setting left property to auto