### PR TITLE
fix: handle embedded parameter in SolidFormFooter to reset navigation…

### DIFF
--- a/src/components/core/form/SolidFormFooter.tsx
+++ b/src/components/core/form/SolidFormFooter.tsx
@@ -92,6 +92,13 @@ export const SolidFormFooter = ({ params }: SolidFormFooterProps) => {
     // Fetch navigation data
     // -----------------------------
     useEffect(() => {
+        if (params.embeded === true) {
+            setPrevNav(null);
+            setNextNav(null);
+            setMeta(null);
+            return;
+        }
+
         if (params.id !== "new") {
 
             const fetchNavigation = async () => {
@@ -127,7 +134,7 @@ export const SolidFormFooter = ({ params }: SolidFormFooterProps) => {
             };
             fetchNavigation();
         }
-    }, [params.id]);
+    }, [params.id, params.embeded]);
 
     // -----------------------------
     // UI


### PR DESCRIPTION
What changed
Added an early return in the footer navigation effect when params.embeded === true.
Reset footer navigation state (prevNav, nextNav, meta) when embedded mode is active.
Prevented model-metadata/navigation API calls for embedded forms.
Updated effect dependencies to include params.embeded for consistent state behavior when mode changes.