### PR TITLE
feat: implement note editing functionality in SolidChatter and SolidM…

### DIFF
--- a/src/components/core/chatter/SolidChatter.tsx
+++ b/src/components/core/chatter/SolidChatter.tsx
@@ -115,15 +115,17 @@ export const SolidChatter = ({ modelSingularName, id, refreshChatterMessage, set
             }).unwrap();
             const processedMessages = response.data.records.map((msg: any) => {
                 if (msg.messageType === 'custom') {
+                    const displayTimeSource = msg.updatedAt || msg.createdAt;
                     // Custom message
                     return {
                         id: msg.id,
                         user: msg.user?.fullName || "System",
+                        userId: msg.user?.id,
                         messageType: "custom",
                         message: msg.messageBody,
-                        time: new Date(msg.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
-                        createdAt: msg.createdAt,
-                        date: formatDate(msg.createdAt),
+                        time: new Date(displayTimeSource).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+                        createdAt: displayTimeSource,
+                        date: formatDate(displayTimeSource),
                         media: msg._media,
                         messageSubType: msg.messageSubType,
                         status: msg.status,
@@ -154,6 +156,7 @@ export const SolidChatter = ({ modelSingularName, id, refreshChatterMessage, set
                     return {
                         id: msg.id,
                         user: msg.user?.fullName || "System",
+                        userId: msg.user?.id,
                         messageType: "audit",
                         time: new Date(msg.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
                         auditRecord: auditRecord,
@@ -229,6 +232,7 @@ export const SolidChatter = ({ modelSingularName, id, refreshChatterMessage, set
                         <SolidChatterMessageBox
                             messageId={message.id}
                             user={message.user}
+                            userId={message.userId}
                             messageType={message.messageType}
                             message={message.message}
                             time={message.time}

--- a/src/components/core/chatter/SolidChatterMessageBox.tsx
+++ b/src/components/core/chatter/SolidChatterMessageBox.tsx
@@ -1,18 +1,20 @@
 
 import { getTextColor, stringToColor } from '../../../helpers/getRandomColors'
 import Image from "../../common/Image"
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import styles from './chatter.module.css'
 import { SolidChatterCustomMessage } from './SolidChatterCustomMessage'
 import { SolidChatterAuditMessage } from './SolidChatterAuditMessage'
-import { Check, GitBranch, MessageSquare } from 'lucide-react'
-import { SolidButton, SolidLightbox, SolidTag, SolidTooltip, SolidTooltipContent, SolidTooltipTrigger, SolidIcon, type SolidIconName } from '../../shad-cn-ui'
+import { Check, GitBranch, MessageSquare, Paperclip, Pencil, Trash2, X } from 'lucide-react'
+import { SolidButton, SolidLightbox, SolidTag, SolidTooltip, SolidTooltipContent, SolidTooltipTrigger, SolidIcon, SolidTextarea, type SolidIconName } from '../../shad-cn-ui'
 import type { SolidLightboxSlide } from '../../shad-cn-ui/SolidLightbox'
-import { usePatchChatterMessageMutation } from '../../../redux/api/solidChatterMessageApi'
+import { usePatchChatterMessageMutation, useUpdateChatterNoteMessageMutation } from '../../../redux/api/solidChatterMessageApi'
+import { useSession } from '../../../hooks/useSession'
 
 interface Props {
     messageId?: number | string,
     user: string,
+    userId?: number,
     messageType?: string,
     message?: any,
     time?: string,
@@ -54,11 +56,22 @@ const getFileIcon = (mimeType: string): SolidIconName => {
 };
 
 export const SolidChatterMessageBox = (props: Props) => {
-    const { messageId, user, messageType, message, time, auditRecord, media, messageSubType, status, modelDisplayName, modelUserKey, onRefresh } = props;
+    const { messageId, user, userId, messageType, message, time, auditRecord, media, messageSubType, status, modelDisplayName, modelUserKey, onRefresh } = props;
     const [lightboxSlides, setLightboxSlides] = useState<SolidLightboxSlide[]>([]);
     const [openLightbox, setOpenLightbox] = useState(false);
     const [taskStatus, setTaskStatus] = useState<string | undefined>(status);
+    const [isEditing, setIsEditing] = useState(false);
+    const [localMessage, setLocalMessage] = useState(message ?? '');
+    const [editedMessage, setEditedMessage] = useState(message ?? '');
+    const [hasPendingOptimisticUpdate, setHasPendingOptimisticUpdate] = useState(false);
+    const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+    const [removedAttachmentIds, setRemovedAttachmentIds] = useState<number[]>([]);
+    const [optimisticRemovedAttachmentIds, setOptimisticRemovedAttachmentIds] = useState<number[]>([]);
+    const [hasPendingOptimisticAttachmentUpdate, setHasPendingOptimisticAttachmentUpdate] = useState(false);
+    const fileInputRef = useRef<HTMLInputElement>(null);
     const [patchChatterMessage, { isLoading: isUpdatingTaskStatus }] = usePatchChatterMessageMutation();
+    const [updateChatterNoteMessage, { isLoading: isUpdatingNote }] = useUpdateChatterNoteMessageMutation();
+    const { data: session } = useSession();
 
     const avatarStyle = useMemo(() => {
         const bg = stringToColor(user)
@@ -116,6 +129,56 @@ export const SolidChatterMessageBox = (props: Props) => {
 
     const isTaskMessage = messageSubType === 'task';
     const isTaskCompleted = (taskStatus ?? '').toLowerCase() === 'completed';
+    const isCustomMessage = messageType === 'custom';
+    const isEditableSubtype = messageSubType === 'custom' || messageSubType === 'note';
+    const isCurrentUserAuthor = !!(session?.user?.id && userId && Number(session.user.id) === Number(userId));
+    const canEditNote = Boolean(messageId && isCustomMessage && isEditableSubtype && isCurrentUserAuthor);
+
+    useEffect(() => {
+        const incomingMessage = message ?? '';
+
+        // Keep optimistic message visible until server data catches up.
+        if (hasPendingOptimisticUpdate && incomingMessage !== localMessage) {
+            return;
+        }
+
+        if (hasPendingOptimisticUpdate && incomingMessage === localMessage) {
+            setHasPendingOptimisticUpdate(false);
+        }
+
+        setLocalMessage(incomingMessage);
+        if (!isEditing) {
+            setEditedMessage(incomingMessage);
+        }
+    }, [message, isEditing, hasPendingOptimisticUpdate, localMessage]);
+
+    useEffect(() => {
+        if (!isEditing) {
+            setSelectedFiles([]);
+            if (!hasPendingOptimisticAttachmentUpdate) {
+                setRemovedAttachmentIds([]);
+            }
+        }
+    }, [isEditing, hasPendingOptimisticAttachmentUpdate]);
+
+    useEffect(() => {
+        if (!hasPendingOptimisticAttachmentUpdate) return;
+        const latestAttachmentIds = (media?.messageAttachments || []).map((attachment) => attachment.id);
+        const stillPresent = optimisticRemovedAttachmentIds.some((id) => latestAttachmentIds.includes(id));
+        if (!stillPresent) {
+            setHasPendingOptimisticAttachmentUpdate(false);
+            setOptimisticRemovedAttachmentIds([]);
+            setRemovedAttachmentIds([]);
+        }
+    }, [media?.messageAttachments, hasPendingOptimisticAttachmentUpdate, optimisticRemovedAttachmentIds]);
+
+    const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
+        if (event.target.files) {
+            const files = Array.from(event.target.files);
+            setSelectedFiles(prev => [...prev, ...files]);
+            event.target.value = '';
+        }
+    };
 
     const handleMarkTaskDone = async () => {
         if (!messageId || isUpdatingTaskStatus) return;
@@ -126,6 +189,72 @@ export const SolidChatterMessageBox = (props: Props) => {
         } catch (e) {
             // no-op (parent/global error handling if any)
         }
+    };
+
+    const handleEditSave = async () => {
+        if (!messageId || isUpdatingNote) return;
+        const trimmedMessage = editedMessage?.trim();
+        const hasBodyChange = trimmedMessage && trimmedMessage !== (message ?? '').trim();
+        const hasAttachmentOps = removedAttachmentIds.length > 0 || selectedFiles.length > 0;
+        if (!hasBodyChange && !hasAttachmentOps) return;
+        if (!trimmedMessage) return;
+        const nextMessage = trimmedMessage;
+        // Optimistic local update to remove UI lag before refetch resolves.
+        setLocalMessage(nextMessage);
+        setHasPendingOptimisticUpdate(true);
+        if (removedAttachmentIds.length > 0) {
+            setOptimisticRemovedAttachmentIds((prev) => Array.from(new Set([...prev, ...removedAttachmentIds])));
+            setHasPendingOptimisticAttachmentUpdate(true);
+        }
+        setIsEditing(false);
+        try {
+            const formData = new FormData();
+            formData.append('messageBody', nextMessage);
+            if (removedAttachmentIds.length > 0) {
+                formData.append('removeAttachmentIds', removedAttachmentIds.join(','));
+            }
+            selectedFiles.forEach((file) => formData.append('messageAttachments', file));
+
+            await updateChatterNoteMessage({ id: messageId, data: formData }).unwrap();
+            onRefresh?.();
+        } catch (e) {
+            // Revert optimistic update on failure.
+            setLocalMessage(message ?? '');
+            setHasPendingOptimisticUpdate(false);
+            setHasPendingOptimisticAttachmentUpdate(false);
+            setOptimisticRemovedAttachmentIds([]);
+            setIsEditing(true);
+        }
+    };
+
+    const handleCancelEdit = () => {
+        setEditedMessage(localMessage ?? '');
+        setSelectedFiles([]);
+        setRemovedAttachmentIds([]);
+        setIsEditing(false);
+    };
+
+    const formatFileSize = (size: number) => {
+        if (!size) return '';
+        return size >= 1024 * 1024
+            ? `${(size / (1024 * 1024)).toFixed(1)} MB`
+            : `${(size / 1024).toFixed(1)} KB`;
+    };
+
+    const hiddenAttachmentIds = new Set([
+        ...removedAttachmentIds,
+        ...optimisticRemovedAttachmentIds,
+    ]);
+    const visibleAttachments = (media?.messageAttachments || []).filter(
+        (attachment) => !hiddenAttachmentIds.has(attachment.id)
+    );
+
+    const toggleRemoveAttachment = (attachmentId: number) => {
+        setRemovedAttachmentIds(prev =>
+            prev.includes(attachmentId)
+                ? prev.filter(id => id !== attachmentId)
+                : [...prev, attachmentId]
+        );
     };
 
     return (
@@ -153,7 +282,21 @@ export const SolidChatterMessageBox = (props: Props) => {
                                     </SolidTooltipContent>
                                 </SolidTooltip>
                             </div>
-                            <span className={styles.solidChatterTime}>{time}</span>
+                            <div className='flex align-items-center gap-2'>
+                                {canEditNote && !isEditing && (
+                                    <SolidButton
+                                        type="button"
+                                        size="sm"
+                                        variant="ghost"
+                                        className="solid-icon-button"
+                                        leftIcon={<Pencil size={12} />}
+                                        onClick={() => setIsEditing(true)}
+                                        aria-label="Edit note"
+                                        title="Edit note"
+                                    />
+                                )}
+                                <span className={styles.solidChatterTime}>{time}</span>
+                            </div>
                         </div>
                         {modelDisplayName && (
                             <p className={`${styles.solidChatterMeta} m-0`}>
@@ -161,17 +304,115 @@ export const SolidChatterMessageBox = (props: Props) => {
                                 {modelUserKey && <> · <span className='font-medium'>{modelUserKey}</span></>}
                             </p>
                         )}
-                        {message && (
+                        {localMessage && !isEditing && (
                             <div className={styles.solidMessageWrapper}>
-                                {renderMessageContent()}
+                                {messageType === 'audit'
+                                    ? <SolidChatterAuditMessage auditRecord={auditRecord} />
+                                    : <SolidChatterCustomMessage message={localMessage} />}
                             </div>
                         )}
-                        {media?.messageAttachments && media.messageAttachments.length > 0 && (
+                        {isEditing && (
+                            <div className='flex flex-column gap-2'>
+                                <SolidTextarea
+                                    value={editedMessage}
+                                    onChange={(e) => setEditedMessage(e.target.value)}
+                                    rows={4}
+                                    className="w-full py-2"
+                                />
+                                <div className='flex flex-column gap-2'>
+                                    <input
+                                        ref={fileInputRef}
+                                        id={`note-edit-file-${messageId}`}
+                                        type="file"
+                                        multiple
+                                        onChange={handleFileSelect}
+                                        style={{ display: 'none' }}
+                                    />
+                                    {selectedFiles.length > 0 && (
+                                        <div className='flex flex-column gap-1'>
+                                            {selectedFiles.map((file, index) => (
+                                                <div key={`${file.name}-${index}`} className='flex align-items-center justify-content-between text-xs'>
+                                                    <span>{file.name} ({formatFileSize(file.size)})</span>
+                                                    <SolidButton
+                                                        type="button"
+                                                        size="sm"
+                                                        variant="ghost"
+                                                        className='solid-icon-button'
+                                                        leftIcon={<X size={12} />}
+                                                        onClick={() => setSelectedFiles(prev => prev.filter((_, i) => i !== index))}
+                                                        aria-label={`Remove ${file.name}`}
+                                                    />
+                                                </div>
+                                            ))}
+                                        </div>
+                                    )}
+                                </div>
+                                <div className='flex align-items-center justify-content-between gap-2 flex-wrap'>
+                                    <div className='flex align-items-center gap-2'>
+                                        <SolidButton
+                                            type="button"
+                                            size="sm"
+                                            variant="ghost"
+                                            className="solid-icon-button"
+                                            leftIcon={<Paperclip size={14} />}
+                                            onClick={() => fileInputRef.current?.click()}
+                                            aria-label="Attach files"
+                                            title="Attach files"
+                                        />
+                                        <span className='text-xs text-color-secondary'>Attach file</span>
+                                    </div>
+                                    <div className='flex align-items-center justify-content-end gap-2'>
+                                    <SolidButton
+                                        type="button"
+                                        size="sm"
+                                        variant="outline"
+                                        leftIcon={<X size={12} />}
+                                        onClick={handleCancelEdit}
+                                    >
+                                        Cancel
+                                    </SolidButton>
+                                    <SolidButton
+                                        type="button"
+                                        size="sm"
+                                        variant="primary"
+                                        loading={isUpdatingNote}
+                                        leftIcon={<Check size={12} />}
+                                        onClick={handleEditSave}
+                                        disabled={!editedMessage?.trim() || (removedAttachmentIds.length === 0 && selectedFiles.length === 0 && editedMessage.trim() === (message ?? '').trim())}
+                                    >
+                                        Save
+                                    </SolidButton>
+                                    </div>
+                                </div>
+                            </div>
+                        )}
+                        {visibleAttachments.length > 0 && (
                             <div className={styles.solidChatterAttachments}>
-                                {media.messageAttachments.map((attachment) => {
+                                {visibleAttachments.map((attachment) => {
                                     const isImage = attachment.mimeType.startsWith('image/');
                                     return (
-                                        <div key={attachment.id} className={styles.solidChatterAttachment}>
+                                        <div key={attachment.id} className={styles.solidChatterAttachment} style={{ position: 'relative' }}>
+                                            {isEditing && canEditNote && (
+                                                <SolidButton
+                                                    type="button"
+                                                    size="sm"
+                                                    variant="ghost"
+                                                    className="solid-icon-button"
+                                                    leftIcon={<Trash2 size={12} color="#dc2626" />}
+                                                    onClick={() => toggleRemoveAttachment(attachment.id)}
+                                                    aria-label={`Remove ${attachment.originalFileName}`}
+                                                    title={`Remove ${attachment.originalFileName}`}
+                                                    style={{
+                                                        position: 'absolute',
+                                                        top: -8,
+                                                        right: -8,
+                                                        zIndex: 2,
+                                                        background: '#fff',
+                                                        border: '1px solid #fecaca',
+                                                        borderRadius: '999px',
+                                                    }}
+                                                />
+                                            )}
                                             {isImage ? (
                                                 <div
                                                     className='cursor-pointer'

--- a/src/components/core/chatter/SolidMessageComposer.tsx
+++ b/src/components/core/chatter/SolidMessageComposer.tsx
@@ -46,7 +46,7 @@ export const SolidMessageComposer = ({ type, modelSingularName, refetch, id, onC
         try {
             const formData = new FormData();
             formData.append('messageType', "custom");
-            formData.append('messageSubType', "custom");
+            formData.append('messageSubType', "note");
             formData.append('messageBody', message);
             formData.append('coModelEntityId', id);
             formData.append('coModelName', modelSingularName);
@@ -111,7 +111,7 @@ export const SolidMessageComposer = ({ type, modelSingularName, refetch, id, onC
                     value={message}
                     onChange={(e) => setMessage(e.target.value)}
                     placeholder={type === 'email' ? 'Send a message to followers' : 'Log an internal note.'}
-                    className="w-full p-1"
+                    className="w-full p-2"
                     rows={4}
                 />
                 <div className='flex align-items-center justify-content-between flex-wrap gap-2'>

--- a/src/redux/api/solidChatterMessageApi.ts
+++ b/src/redux/api/solidChatterMessageApi.ts
@@ -27,8 +27,17 @@ export const solidChatterMessageApi = createApi({
                     body: data
                 }
             }
+        }),
+        updateChatterNoteMessage: builder.mutation({
+            query: ({ id, data }) => {
+                return {
+                    url: `/chatter-message/${id}/note`,
+                    method: 'PATCH',
+                    body: data
+                }
+            }
         })
     })
 });
 
-export const { useGetchatterMessageQuery, useLazyGetchatterMessageQuery, useCreateChatterMessageMutation, usePatchChatterMessageMutation } = solidChatterMessageApi;
+export const { useGetchatterMessageQuery, useLazyGetchatterMessageQuery, useCreateChatterMessageMutation, usePatchChatterMessageMutation, useUpdateChatterNoteMessageMutation } = solidChatterMessageApi;


### PR DESCRIPTION
feat(chatter-ui): enable inline note editing with attachment management and optimistic updates

add note edit mutation hook for PATCH /chatter-message/:id/note
show Edit action only for eligible custom/note messages owned by active user
add inline edit mode with Save/Cancel and immediate optimistic message update
support attachment add in edit mode via attach icon + label
support per-attachment remove in edit mode with small top-right remove icon
keep removed attachments hidden optimistically until server refresh confirms
show custom note time using updatedAt fallback to createdAt after edits