### PR TITLE
fix: restrict editable message subtype to 'note'

### DIFF
--- a/src/components/core/chatter/SolidChatterMessageBox.tsx
+++ b/src/components/core/chatter/SolidChatterMessageBox.tsx
@@ -130,7 +130,7 @@ export const SolidChatterMessageBox = (props: Props) => {
     const isTaskMessage = messageSubType === 'task';
     const isTaskCompleted = (taskStatus ?? '').toLowerCase() === 'completed';
     const isCustomMessage = messageType === 'custom';
-    const isEditableSubtype = messageSubType === 'custom' || messageSubType === 'note';
+    const isEditableSubtype = messageSubType === 'note';
     const isCurrentUserAuthor = !!(session?.user?.id && userId && Number(session.user.id) === Number(userId));
     const canEditNote = Boolean(messageId && isCustomMessage && isEditableSubtype && isCurrentUserAuthor);
 


### PR DESCRIPTION
Previously, message editing was incorrectly enabled for custom audit messages as well. This change limits editability exclusively to the "note" subtype and fixes the unintended behavior.