### PR TITLE
Restore Microsoft Active Directory OAuth (revert revert of #97)

### DIFF
--- a/src/adapters/auth/signInWithOAuthAccessCode.ts
+++ b/src/adapters/auth/signInWithOAuthAccessCode.ts
@@ -15,7 +15,7 @@ type SignInResponse = {
 type SignInWithOAuthAccessCodeOptions = {
   accessCode: string;
   userAgent?: string;
-  provider?: "google" | "facebook" | "microsoft";
+  provider?: "google" | "facebook" | "microsoft" | "microsoft-active-directory";
 };
 
 export async function signInWithOAuthAccessCode(options: SignInWithOAuthAccessCodeOptions): Promise<SignInResponse> {

--- a/src/components/auth/MicrosoftActiveDirectoryAuthChecking.tsx
+++ b/src/components/auth/MicrosoftActiveDirectoryAuthChecking.tsx
@@ -1,0 +1,78 @@
+import { ERROR_MESSAGES } from "../../constants/error-messages";
+import { signInWithOAuthAccessCode } from "../../adapters/auth/index";
+import { useRouter } from "../../hooks/useRouter";
+import { useSearchParams } from "../../hooks/useSearchParams";
+import { useEffect, useState } from "react";
+import { useDispatch } from "react-redux";
+import { env } from "../../adapters/env";
+import { showToast } from "../../redux/features/toastSlice";
+import { SolidSpinner } from "../shad-cn-ui";
+
+export const MicrosoftActiveDirectoryAuthChecking = () => {
+  const searchParams = useSearchParams();
+  const accessCode = searchParams.get("accessCode");
+
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const handleOAuthAuthentication = async () => {
+      if (!accessCode) {
+        dispatch(
+          showToast({
+            severity: "error",
+            summary: ERROR_MESSAGES.LOGIN_ERROR,
+            detail: ERROR_MESSAGES.AUTHENICATION__FAILED,
+          }),
+        );
+        setError(ERROR_MESSAGES.AUTHENICATION__FAILED);
+        return;
+      }
+
+      try {
+        const response = await signInWithOAuthAccessCode({
+          accessCode: accessCode,
+          provider: "microsoft-active-directory",
+        });
+
+        if (response?.error) {
+          dispatch(
+            showToast({
+              severity: "error",
+              summary: ERROR_MESSAGES.LOGIN_ERROR,
+              detail: response.error,
+            }),
+          );
+          setError(response.error || ERROR_MESSAGES.AUTHENICATION__FAILED);
+        } else {
+          const redirectUrl = env("NEXT_PUBLIC_LOGIN_REDIRECT_URL") || "/admin";
+          router.push(redirectUrl);
+        }
+      } catch (err: any) {
+        const message =
+          err?.data?.message || ERROR_MESSAGES.AUTHENICATION__FAILED;
+        dispatch(
+          showToast({
+            severity: "error",
+            summary: ERROR_MESSAGES.LOGIN_ERROR,
+            detail: message,
+          }),
+        );
+        setError(message);
+      }
+    };
+
+    handleOAuthAuthentication();
+  }, [accessCode, dispatch, router]);
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <h2 className="text-red-500 text-xl font-semibold">{error}</h2>
+      </div>
+    );
+  }
+
+  return <SolidSpinner className="flex items-center justify-center min-h-screen" />;
+};

--- a/src/components/auth/SolidLogin.tsx
+++ b/src/components/auth/SolidLogin.tsx
@@ -358,7 +358,8 @@ const SolidLogin = ({ signInValidatorLabel, signInValidatorPlaceholder }: any) =
         solidSettingsData?.data?.iamGoogleOAuthEnabled ||
         solidSettingsData?.data?.iamFacebookOAuthEnabled ||
         solidSettingsData?.data?.iamAppleOAuthEnabled ||
-        solidSettingsData?.data?.iamMicrosoftOAuthEnabled
+        solidSettingsData?.data?.iamMicrosoftOAuthEnabled ||
+        solidSettingsData?.data?.iamMicrosoftActiveDirectoryOAuthEnabled
     );
 
     return (
@@ -380,6 +381,7 @@ const SolidLogin = ({ signInValidatorLabel, signInValidatorPlaceholder }: any) =
                             facebookEnabled={solidSettingsData?.data?.iamFacebookOAuthEnabled}
                             appleEnabled={solidSettingsData?.data?.iamAppleOAuthEnabled}
                             microsoftEnabled={solidSettingsData?.data?.iamMicrosoftOAuthEnabled}
+                            microsoftActiveDirectoryEnabled={solidSettingsData?.data?.iamMicrosoftActiveDirectoryOAuthEnabled}
                         />
                     </>
                 )}

--- a/src/components/auth/SolidRegister.tsx
+++ b/src/components/auth/SolidRegister.tsx
@@ -431,7 +431,8 @@ const SolidRegister = () => {
         solidSettingsData?.data?.iamGoogleOAuthEnabled ||
         solidSettingsData?.data?.iamFacebookOAuthEnabled ||
         solidSettingsData?.data?.iamAppleOAuthEnabled ||
-        solidSettingsData?.data?.iamMicrosoftOAuthEnabled
+        solidSettingsData?.data?.iamMicrosoftOAuthEnabled ||
+        solidSettingsData?.data?.iamMicrosoftActiveDirectoryOAuthEnabled
     );
     return (
         <div className="">
@@ -470,6 +471,7 @@ const SolidRegister = () => {
                             facebookEnabled={solidSettingsData?.data?.iamFacebookOAuthEnabled}
                             appleEnabled={solidSettingsData?.data?.iamAppleOAuthEnabled}
                             microsoftEnabled={solidSettingsData?.data?.iamMicrosoftOAuthEnabled}
+                            microsoftActiveDirectoryEnabled={solidSettingsData?.data?.iamMicrosoftActiveDirectoryOAuthEnabled}
                         />
                     </>
                 )}

--- a/src/components/common/GeneralSettings.tsx
+++ b/src/components/common/GeneralSettings.tsx
@@ -47,6 +47,7 @@ export const GeneralSettings = () => {
         activateUserOnRegistration: solidSettingsData?.data?.activateUserOnRegistration ?? false,
         iamGoogleOAuthEnabled: solidSettingsData?.data?.iamGoogleOAuthEnabled ?? false,
         iamMicrosoftOAuthEnabled: solidSettingsData?.data?.iamMicrosoftOAuthEnabled ?? false,
+        iamMicrosoftActiveDirectoryOAuthEnabled: solidSettingsData?.data?.iamMicrosoftActiveDirectoryOAuthEnabled ?? false,
         iamFacebookOAuthEnabled: solidSettingsData?.data?.iamFacebookOAuthEnabled ?? false,
         iamAppleOAuthEnabled: solidSettingsData?.data?.iamAppleOAuthEnabled ?? false,
         // shouldQueueEmails: solidSettingsData?.data?.shouldQueueEmails ?? false,
@@ -892,6 +893,27 @@ export const GeneralSettings = () => {
                         <div className="w-full px-2 pt-2 mt-4">
                           <div className="flex flex-wrap items-center -mx-2 -mt-2">
                             <div className="w-[83.333333%] sm:w-[75%] lg:w-[41.666667%] px-2 pt-2">
+                              <label className="form-field-label">
+                                Allow Login/ Signup with Microsoft Active Directory{" "}
+                              </label>
+                            </div>
+                            <div className="col-2 sm:col-3 lg:col-7">
+                              <SolidSwitch
+                                name="iamMicrosoftActiveDirectoryOAuthEnabled"
+                                checked={formik.values.iamMicrosoftActiveDirectoryOAuthEnabled}
+                                onChange={(checked) =>
+                                  formik.setFieldValue(
+                                    "iamMicrosoftActiveDirectoryOAuthEnabled",
+                                    checked,
+                                  )
+                                }
+                              />
+                            </div>
+                          </div>
+                        </div>
+                        <div className="col-12 mt-3">
+                          <div className="formgrid grid align-items-center">
+                            <div className="col-10 sm:col-9 lg:col-5">
                               <label className="form-field-label">
                                 Allow Login/ Signup with Facebook{" "}
                               </label>

--- a/src/components/common/SocialMediaLogin.tsx
+++ b/src/components/common/SocialMediaLogin.tsx
@@ -7,6 +7,7 @@ type SocialMediaLoginProps = {
   facebookEnabled?: boolean;
   appleEnabled?: boolean;
   microsoftEnabled?: boolean;
+  microsoftActiveDirectoryEnabled?: boolean;
 };
 
 export const SocialMediaLogin = ({
@@ -14,13 +15,15 @@ export const SocialMediaLogin = ({
   facebookEnabled = false,
   appleEnabled = false,
   microsoftEnabled = false,
+  microsoftActiveDirectoryEnabled = false,
 }: SocialMediaLoginProps) => {
   const router = useRouter();
 
-  const googleApiConnectRedirectUrl = `${env("NEXT_PUBLIC_BACKEND_API_URL")}/api/iam/google/connect`;
-  const facebookApiConnectRedirectUrl = `${env("NEXT_PUBLIC_BACKEND_API_URL")}/api/iam/facebook/connect`;
-  const appleApiConnectRedirectUrl = `${env("NEXT_PUBLIC_BACKEND_API_URL")}/api/iam/apple/connect`;
-  const microsoftApiConnectRedirectUrl = `${env("NEXT_PUBLIC_BACKEND_API_URL")}/api/iam/microsoft/connect`;
+  const backendApiUrl = (
+    env("NEXT_PUBLIC_BACKEND_API_URL") || env("API_URL")
+  ).replace(/\/+$/, "");
+  const getOAuthConnectUrl = (provider: string) =>
+    `${backendApiUrl}/api/iam/${provider}/connect`;
 
   return (
     <div className="mt-4">
@@ -31,8 +34,9 @@ export const SocialMediaLogin = ({
           variant="outline"
           className="solid-auth-social-btn"
           tabIndex={-1}
-          onClick={() => router.push(appleApiConnectRedirectUrl)}
+          onClick={() => router.push(getOAuthConnectUrl("apple"))}
           aria-label="Login with Apple"
+          title="Login with Apple"
         >
           <svg
             viewBox="0 0 24 24"
@@ -52,8 +56,9 @@ export const SocialMediaLogin = ({
           variant="outline"
           className="solid-auth-social-btn"
           tabIndex={-1}
-          onClick={() => router.push(googleApiConnectRedirectUrl)}
+          onClick={() => router.push(getOAuthConnectUrl("google"))}
           aria-label="Login with Google"
+          title="Login with Google"
         >
           <svg
             viewBox="0 0 24 24"
@@ -88,8 +93,9 @@ export const SocialMediaLogin = ({
           variant="outline"
           className="solid-auth-social-btn"
           tabIndex={-1}
-          onClick={() => router.push(facebookApiConnectRedirectUrl)}
+          onClick={() => router.push(getOAuthConnectUrl("facebook"))}
           aria-label="Login with Meta"
+          title="Login with Meta"
         >
           <svg
             viewBox="0 0 24 24"
@@ -115,8 +121,30 @@ export const SocialMediaLogin = ({
           variant="outline"
           className="solid-auth-social-btn"
           tabIndex={-1}
-          onClick={() => router.push(microsoftApiConnectRedirectUrl)}
+          onClick={() => router.push(getOAuthConnectUrl("microsoft"))}
           aria-label="Login with Microsoft"
+          title="Login with Microsoft"
+        >
+          <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+            <g transform="translate(2, 2)">
+              <rect width="9" height="9" x="0" y="0" fill="#f25022" />
+              <rect width="9" height="9" x="11" y="0" fill="#7fba00" />
+              <rect width="9" height="9" x="0" y="11" fill="#00a4ef" />
+              <rect width="9" height="9" x="11" y="11" fill="#ffb900" />
+            </g>
+          </svg>
+        </SolidButton>
+        )}
+
+        {microsoftActiveDirectoryEnabled && (
+        <SolidButton
+          type="button"
+          variant="outline"
+          className="solid-auth-social-btn"
+          tabIndex={-1}
+          onClick={() => router.push(getOAuthConnectUrl("microsoft-active-directory"))}
+          aria-label="Login with Microsoft Active Directory"
+          title="Login with Microsoft Active Directory"
         >
           <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
             <g transform="translate(2, 2)">

--- a/src/index.ts
+++ b/src/index.ts
@@ -436,6 +436,7 @@ export { default as SolidInitiateRegisterOtp } from './components/auth/SolidInit
 export { GoogleAuthChecking } from './components/auth/GoogleAuthChecking';
 export { FacebookAuthChecking } from './components/auth/FacebookAuthChecking';
 export { MicrosoftAuthChecking } from './components/auth/MicrosoftAuthChecking';
+export { MicrosoftActiveDirectoryAuthChecking } from './components/auth/MicrosoftActiveDirectoryAuthChecking';
 export { ForgotPasswordThankYou } from './components/auth/ForgotPasswordThankYou';
 export { 
   SolidButton, 
@@ -604,6 +605,7 @@ export { InitiateRegisterPage as AuthInitiateRegisterPage } from './routes/pages
 export { InitiateGoogleOauthPage as AuthInitiateGoogleOauthPage } from './routes/pages/auth/InitiateGoogleOauthPage';
 export { InitiateFacebookOauthPage as AuthInitiateFacebookOauthPage } from './routes/pages/auth/InitiateFacebookOauthPage';
 export { InitiateMicrosoftOauthPage as AuthInitiateMicrosoftOauthPage } from './routes/pages/auth/InitiateMicrosoftOauthPage';
+export { InitiateMicrosoftActiveDirectoryOauthPage as AuthInitiateMicrosoftActiveDirectoryOauthPage } from './routes/pages/auth/InitiateMicrosoftActiveDirectoryOauthPage';
 export { SsoPage as AuthSsoPage } from './routes/pages/auth/SsoPage';
 export { ErrorPage } from './routes/pages/ErrorPage';
 export { NotFoundPage } from './routes/pages/NotFoundPage';

--- a/src/resources/solid-custom.css
+++ b/src/resources/solid-custom.css
@@ -236,7 +236,7 @@ body {
   position: fixed;
   inset: 0;
   background: rgba(2, 6, 23, 0.4);
-  z-index: 59;
+  z-index: 100;
 }
 
 .solid-sidebar-mobile-trigger {
@@ -261,7 +261,7 @@ body {
   background: var(--sidebar-background);
   color: var(--sidebar-foreground);
   border-right: 1px solid var(--sidebar-border);
-  z-index: 60;
+  z-index: 100;
   display: flex;
   flex-direction: column;
   transition: width 200ms ease, transform 200ms ease, top 220ms ease, height 220ms ease;

--- a/src/routes/pages/auth/InitiateMicrosoftActiveDirectoryOauthPage.tsx
+++ b/src/routes/pages/auth/InitiateMicrosoftActiveDirectoryOauthPage.tsx
@@ -1,0 +1,5 @@
+import { MicrosoftActiveDirectoryAuthChecking } from "../../../components/auth/MicrosoftActiveDirectoryAuthChecking";
+
+export function InitiateMicrosoftActiveDirectoryOauthPage() {
+  return <MicrosoftActiveDirectoryAuthChecking />;
+}

--- a/src/routes/solidRoutes.tsx
+++ b/src/routes/solidRoutes.tsx
@@ -27,6 +27,7 @@ import { InitiateRegisterPage } from "./pages/auth/InitiateRegisterPage";
 import { InitiateGoogleOauthPage } from "./pages/auth/InitiateGoogleOauthPage";
 import { InitiateFacebookOauthPage } from "./pages/auth/InitiateFacebookOauthPage";
 import { InitiateMicrosoftOauthPage } from "./pages/auth/InitiateMicrosoftOauthPage";
+import { InitiateMicrosoftActiveDirectoryOauthPage } from "./pages/auth/InitiateMicrosoftActiveDirectoryOauthPage";
 import { SsoPage } from "./pages/auth/SsoPage";
 import type { SolidRoutesOptions, SolidRouteKey } from "./types";
 import { TreePage } from "./pages/admin/core/TreePage";
@@ -72,6 +73,7 @@ export function getSolidRoutes(options: SolidRoutesOptions = {}): RouteObject[] 
     { path: "/auth/initiate-google-oauth", element: pick("initiateGoogleOauth", <InitiateGoogleOauthPage />), handle: { title: "Google Sign In", manageDocumentMeta: true } },
     { path: "/auth/initiate-facebook-oauth", element: pick("initiateFacebookOauth", <InitiateFacebookOauthPage />), handle: { title: "Facebook Sign In", manageDocumentMeta: true } },
     { path: "/auth/initiate-microsoft-oauth", element: pick("initiateMicrosoftOauth", <InitiateMicrosoftOauthPage />), handle: { title: "Microsoft Sign In", manageDocumentMeta: true } },
+    { path: "/auth/initiate-microsoft-active-directory-oauth", element: pick("initiateMicrosoftActiveDirectoryOauth", <InitiateMicrosoftActiveDirectoryOauthPage />), handle: { title: "Microsoft Active Directory Sign In", manageDocumentMeta: true } },
     { path: "/auth/sso", element: pick("sso", <SsoPage />), handle: { title: "Single Sign-On", manageDocumentMeta: true } },
     ...extraAuthRoutes,
   ];

--- a/src/routes/types.ts
+++ b/src/routes/types.ts
@@ -25,6 +25,7 @@ export type SolidRouteKey =
   | "initiateGoogleOauth"
   | "initiateFacebookOauth"
   | "initiateMicrosoftOauth"
+  | "initiateMicrosoftActiveDirectoryOauth"
   | "sso"
   | "admin"
   | "moduleHome"


### PR DESCRIPTION
Reverts the revert from PR #107 (commit 28a16424), re-applying the active-directory OAuth feature originally added in PR #97 (c8cb6369). All 11 files restored byte-identically to the original feature.