### PR TITLE
feat: integrate DOMPurify for sanitizing rich text and update form data

### DIFF
--- a/src/components/core/form/fields/SolidRichTextField.tsx
+++ b/src/components/core/form/fields/SolidRichTextField.tsx
@@ -1,5 +1,6 @@
 
-import React, { useEffect } from "react";
+import React from "react";
+import DOMPurify from "dompurify";
 import { SolidMessage } from "../../../shad-cn-ui/SolidMessage";
 import { SolidRichTextEditor } from "../../../shad-cn-ui/SolidRichTextEditor";
 import * as Yup from 'yup';
@@ -65,6 +66,7 @@ const normalizeQuillRichTextHtml = (html: string): string => {
             currentList.appendChild(node);
         });
 
+        appendCurrentList();
         orderedList.replaceWith(replacementFragment);
     });
 
@@ -82,7 +84,7 @@ export class SolidRichTextField implements ISolidField {
     updateFormData(value: any, formData: FormData): any {
         const fieldLayoutInfo = this.fieldContext.field;
         if (value !== undefined && value !== null) {
-            formData.append(fieldLayoutInfo.attrs.name, value);
+            formData.append(fieldLayoutInfo.attrs.name, normalizeQuillRichTextHtml(value));
         }
     }
 
@@ -189,25 +191,6 @@ export const DefaultRichTextFormEditWidget = ({ formik, fieldContext }: SolidFor
     const formDisabled = solidFormViewMetaData.data.solidView?.layout?.attrs?.disabled;
     const formReadonly = solidFormViewMetaData.data.solidView?.layout?.attrs?.readonly;
     const fieldName = fieldLayoutInfo.attrs.name;
-    const fieldValue = formik.values[fieldName] || "";
-    const normalizedFieldValue = normalizeQuillRichTextHtml(fieldValue);
-
-    useEffect(() => {
-        if (fieldValue === normalizedFieldValue) {
-            return;
-        }
-
-        fieldContext.onChange(
-            {
-                target: {
-                    name: fieldName,
-                    value: normalizedFieldValue,
-                    type: "text",
-                },
-            } as any,
-            "onFieldChange"
-        );
-    }, [fieldContext, fieldName, fieldValue, normalizedFieldValue]);
 
 
     return (
@@ -222,14 +205,13 @@ export const DefaultRichTextFormEditWidget = ({ formik, fieldContext }: SolidFor
             <SolidRichTextEditor
                 readOnly={formReadonly || fieldReadonly || readOnlyPermission || formDisabled || fieldDisabled}
                 id={fieldName}
-                value={normalizedFieldValue}
+                value={formik.values[fieldName] || ""}
                 onChange={(value) => {
-                    const normalizedValue = normalizeQuillRichTextHtml(value ?? "");
                     fieldContext.onChange(
                         {
                             target: {
                                 name: fieldName,
-                                value: normalizedValue,
+                                value: value ?? "",
                                 type: "text",
                             },
                         } as any,
@@ -259,7 +241,7 @@ export const DefaultRichTextFormViewWidget = ({ formik, fieldContext }: SolidFor
             <div
                 className="solid-custom-editor solid-custom-editor-view"
                 id={fieldLabel}
-                dangerouslySetInnerHTML={{ __html: formik.values[fieldLayoutInfo.attrs.name] || "" }}
+                dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(normalizeQuillRichTextHtml(formik.values[fieldLayoutInfo.attrs.name] || "")) }}
             />
         </div>
     );


### PR DESCRIPTION
There were 2 separate problems in SolidRichTextField.tsx
The earlier edit-time normalization was interfering with Quill while typing.
That caused bullets to disappear from the editor and dirty-state to reset.

The normalizer itself had a bug:
it built currentList but never appended the final list into the fragment before orderedList.replaceWith(...).
So the conversion could fail or drop the converted list entirely.