### PR TITLE
fix: ui-mobile-responsive

### DIFF
--- a/src/components/common/SettingsComponent.module.css
+++ b/src/components/common/SettingsComponent.module.css
@@ -466,6 +466,75 @@
   color: var(--muted-foreground);
 }
 
+/* Keep the settings workspace within the mobile viewport. The desktop layout
+   intentionally uses a fixed vertical module rail, but that rail leaves too
+   little room for nested AI settings tabs and their provider table on phones. */
+@media (max-width: 767px) {
+  .page {
+    height: auto;
+    min-height: calc(100dvh - 46px);
+    overflow-x: hidden;
+  }
+
+  .pageHeader {
+    grid-template-columns: minmax(0, 1fr);
+    align-items: stretch;
+  }
+
+  .headerSearch,
+  .searchIcon {
+    width: 100%;
+    max-width: none;
+  }
+
+  .toolbarActions {
+    justify-content: space-between;
+  }
+
+  .tabGroup {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .tabList {
+    flex: 0 0 auto;
+    flex-direction: row;
+    overflow-x: auto;
+    overflow-y: hidden;
+    border-right: 0;
+    border-bottom: 1px solid color-mix(in srgb, var(--border) 86%, transparent);
+  }
+
+  .tabPanel {
+    width: 100%;
+    min-width: 0;
+    overflow-x: auto;
+    padding: 0.75rem 0.65rem 1rem;
+  }
+
+  .settingRow {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .customControlStack,
+  .customControlStack :global(.solid-notebook),
+  .customControlStack :global(.solid-notebook-content) {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .customControlStack :global(.solid-notebook-tablist) {
+    max-width: 100%;
+    overflow-x: auto;
+  }
+
+  .customControlStack :global(.solid-ai-model-config-card) {
+    width: 100% !important;
+  }
+}
+
 .pageHeader :global(.form-wrapper-title) {
   color: var(--foreground) !important;
 }

--- a/src/components/common/SettingsComponent.module.css
+++ b/src/components/common/SettingsComponent.module.css
@@ -201,6 +201,7 @@
   padding: 0.85rem 0.95rem 1rem;
   overflow-y: auto;
   min-height: 0;
+  overflow-x: hidden;
 }
 
 .moduleTab {
@@ -209,6 +210,7 @@
   gap: 0.75rem;
   text-align: left;
   width: 100%;
+  min-width: 0;
 }
 
 .moduleTabBadge {
@@ -230,6 +232,7 @@
   flex-direction: column;
   gap: 0.15rem;
   min-width: 0;
+  overflow: hidden;
 }
 
 .moduleTabLabel {
@@ -241,6 +244,14 @@
 .moduleTabMeta {
   font-size: 0.72rem;
   color: var(--muted-foreground);
+}
+
+.moduleTabLabel,
+.moduleTabMeta {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .groupSection + .groupSection {
@@ -354,6 +365,7 @@
 
 .readonlyValue {
   min-height: 2.45rem;
+  max-width: 100%;
   display: flex;
   align-items: center;
   color: var(--foreground);
@@ -362,6 +374,8 @@
   border-radius: 0.9rem;
   border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
   background: color-mix(in srgb, var(--surface-ground, var(--card)) 78%, var(--card) 22%);
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .emptyValue {
@@ -482,6 +496,12 @@
 
 .workspace :global(.solid-tabs--vertical .solid-notebook-tab-trigger.active) {
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--primary) 24%, transparent);
+}
+
+.workspace :global(.solid-notebook-tablist.solid-tabs-list) {
+  width: 100% !important;
+  max-width: 100%;
+  min-width: 0;
 }
 
 :global(html.dark) .pageHeader,

--- a/src/components/common/SolidSettings/LlmSettings/AiModelConfigTab.tsx
+++ b/src/components/common/SolidSettings/LlmSettings/AiModelConfigTab.tsx
@@ -339,7 +339,7 @@ export const ModelConfigTab = ({ modelEntry, providers, onModelEntryChange }: Mo
 
   return (
     <div className="flex flex-col gap-6">
-      <div style={{ ...cardStyle, width: "50%" }}>
+      <div className="solid-ai-model-config-card" style={{ ...cardStyle, width: "50%" }}>
         <p className="solid-settings-subheading">Model Config</p>
         <div className="flex flex-col gap-4 mt-4">
           <div>
@@ -365,7 +365,7 @@ export const ModelConfigTab = ({ modelEntry, providers, onModelEntryChange }: Mo
         </div>
       </div>
 
-      <div style={{ ...cardStyle, width: "50%" }}>
+      <div className="solid-ai-model-config-card" style={{ ...cardStyle, width: "50%" }}>
         <p className="solid-settings-subheading">Behavior</p>
         <div className="flex flex-col gap-4 mt-4">
           <div className="flex items-center gap-2">

--- a/src/components/core/locales/SolidLocale.tsx
+++ b/src/components/core/locales/SolidLocale.tsx
@@ -194,6 +194,7 @@ const SolidLocale = ({ solidFormViewMetaData, id, selectedLocale, setSelectedLoc
                                 value={selectedLocale}
                                 onChange={(e) => handleLocaleChange(e.value)}
                                 options={localeOptions}
+                                native={false}
                                 placeholder="Select locale"
                                 className="w-full solid-locale-select"
                                 disabled={createMode}

--- a/src/components/core/locales/solid-locale.css
+++ b/src/components/core/locales/solid-locale.css
@@ -175,6 +175,9 @@
 
 .solid-locale-i18n-panel {
   margin-top: 0.65rem;
+  overflow: visible;
+  position: relative;
+  z-index: 2;
 }
 
 .solid-locale-i18n-body {
@@ -214,6 +217,8 @@
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
+  position: relative;
+  z-index: 3;
 }
 
 .solid-locale-i18n-label {
@@ -225,6 +230,10 @@
 
 .solid-locale-select {
   min-height: 34px;
+}
+
+.solid-locale-select .solid-select-menu {
+  z-index: calc(var(--z-overlay) + 8);
 }
 
 .solid-workflow-pill {

--- a/src/components/core/model/FieldMetaDataForm.css
+++ b/src/components/core/model/FieldMetaDataForm.css
@@ -127,6 +127,24 @@
   line-height: 1.15;
 }
 
+.solid-field-selection-static-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.solid-field-selection-static-row .solid-standard-input {
+  min-width: 0;
+}
+
+.solid-field-selection-static-row .solid-btn {
+  width: 2.125rem;
+  min-width: 2.125rem;
+  height: 2.125rem;
+  padding: 0;
+}
+
 .solid-field-form-actions {
   display: flex;
   align-items: center;

--- a/src/components/core/model/FieldMetaDataForm.css
+++ b/src/components/core/model/FieldMetaDataForm.css
@@ -115,6 +115,18 @@
   margin-top: 0;
 }
 
+.solid-field-relation-type-control {
+  align-self: stretch;
+}
+
+.solid-field-relation-type-control .solid-segmented-item {
+  flex: 1 1 0;
+  min-width: 0;
+  padding-inline: 0.75rem;
+  white-space: normal;
+  line-height: 1.15;
+}
+
 .solid-field-form-actions {
   display: flex;
   align-items: center;
@@ -232,5 +244,10 @@ html.dark .solid-field-form-shell .solid-file-icon-btn.is-danger:hover:not(:disa
 @media (max-width: 380px) {
   .solid-field-settings-grid {
     grid-template-columns: 1fr;
+  }
+
+  .solid-field-relation-type-control .solid-segmented-item {
+    padding-inline: 0.5rem;
+    font-size: 0.75rem;
   }
 }

--- a/src/components/core/model/FieldMetaDataForm.css
+++ b/src/components/core/model/FieldMetaDataForm.css
@@ -96,6 +96,25 @@
   margin: 0;
 }
 
+.solid-field-settings-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem 1.25rem;
+  align-items: stretch;
+}
+
+.solid-field-settings-item {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.solid-field-settings-item .fieldSubTitle,
+.solid-field-settings-item .text-xs {
+  margin-top: 0;
+}
+
 .solid-field-form-actions {
   display: flex;
   align-items: center;
@@ -207,5 +226,11 @@ html.dark .solid-field-form-shell .solid-file-icon-btn.is-danger:hover:not(:disa
 
   .solid-field-form-actions .solid-btn {
     width: 100%;
+  }
+}
+
+@media (max-width: 380px) {
+  .solid-field-settings-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/components/core/model/FieldMetaDataForm.tsx
+++ b/src/components/core/model/FieldMetaDataForm.tsx
@@ -171,7 +171,7 @@ function TabView({ children, panelContainerClassName }: LocalTabViewProps) {
     label: panel.props.header,
     hasError: panel.props.className?.includes("tab-error-heading"),
     content: (
-      <div className={panel.props.className}>
+      <div>
         {panel.props.children}
       </div>
     ),
@@ -1514,6 +1514,15 @@ const FieldMetaDataForm = ({
     ? `Edit ${formik?.values?.displayName || fieldTypeLabel} Field`
     : `Add ${fieldTypeLabel} Field`;
 
+  const basicInfoFieldNames = ["displayName", "name", "description", "columnName"];
+  const formikTouchedFields = formik.touched as Record<string, unknown>;
+  const formikErrorFields = formik.errors as Record<string, unknown>;
+  const fieldHasTouchedError = (fieldName: string) => Boolean(formikTouchedFields[fieldName] && formikErrorFields[fieldName]);
+  const basicInfoHasError = basicInfoFieldNames.some(fieldHasTouchedError);
+  const advancedConfigHasError = Object.keys(formikErrorFields).some(
+    (fieldName) => !basicInfoFieldNames.includes(fieldName) && fieldHasTouchedError(fieldName)
+  );
+
   const mediaTypeSelectedItems = useMemo(() => {
     if (!Array.isArray(formik.values.mediaTypes)) return [];
     return formik.values.mediaTypes.map((entry: any) => {
@@ -1584,6 +1593,13 @@ const FieldMetaDataForm = ({
   ]);
 
   const showError = async () => {
+    formik.setTouched(
+      currentFields.reduce((touchedFields: Record<string, boolean>, fieldName: string) => {
+        touchedFields[fieldName] = true;
+        return touchedFields;
+      }, {}),
+      false
+    );
     const errors = await formik.validateForm(); // Trigger validation and get the updated errors
     const collectMessages = (value: any): string[] => {
       if (!value) return [];
@@ -1899,12 +1915,12 @@ const FieldMetaDataForm = ({
                     <TabView panelContainerClassName="px-0">
                     <TabPanel
                       header="Basic Info"
-                      className={(formik.touched.hasOwnProperty("name") && formik.errors.hasOwnProperty("name")) || (formik.touched.hasOwnProperty("displayName") && formik.errors.hasOwnProperty("displayName")) || (formik.touched.hasOwnProperty("displayName") && formik.errors.hasOwnProperty("ormType")) ? "tab-error-heading" : ""}
+                      className={basicInfoHasError ? "tab-error-heading" : ""}
                     // rightIcon="si si-info-circle ml-2"
                     >
                       <div className="flex flex-wrap -mx-2 -mt-2">
                         {currentFields.includes("displayName") && (
-                          <div className="field mt-2 px-2 pt-2 md:w-1/2">
+                          <div className="field mt-2 min-w-0 basis-full px-2 pt-2 md:basis-1/2">
                             <label htmlFor="displayName" className={classNames("form-field-label", styles.fieldLabel)}>
                               Display Name
                             </label>
@@ -1933,7 +1949,7 @@ const FieldMetaDataForm = ({
                         )}
 
                         {currentFields.includes("name") && (
-                          <div className="field mt-2 px-2 pt-2 md:mt-0 md:w-1/2">
+                          <div className="field mt-2 min-w-0 basis-full px-2 pt-2 md:mt-0 md:basis-1/2">
                             <label htmlFor="name" className={classNames("form-field-label", styles.fieldLabel)}>
                               Name
                             </label>
@@ -1954,7 +1970,7 @@ const FieldMetaDataForm = ({
                           </div>
                         )}
                         {currentFields.includes("description") && (
-                          <div className="field mt-2 w-full px-2 pt-2 md:mt-2 md:w-1/2">
+                          <div className="field mt-2 min-w-0 basis-full px-2 pt-2 md:mt-2 md:basis-1/2">
                             <label htmlFor="description" className={classNames("form-field-label", styles.fieldLabel)}>
                               Description
                             </label>
@@ -1976,7 +1992,7 @@ const FieldMetaDataForm = ({
                         )}
 
                         {currentFields.includes("columnName") && (
-                          <div className="field mt-2 w-full px-2 pt-2 md:w-1/2">
+                          <div className="field mt-2 min-w-0 basis-full px-2 pt-2 md:basis-1/2">
                             <div className="flex items-center gap-2">
                               <SolidCheckbox
                                 onChange={(event) => {
@@ -2028,7 +2044,9 @@ const FieldMetaDataForm = ({
 
                     </TabPanel>
 
-                    <TabPanel header="Advanced Config"
+                    <TabPanel
+                      header="Advanced Config"
+                      className={advancedConfigHasError ? "tab-error-heading" : ""}
 
                     //  rightIcon="si si-cog ml-2"
                     >
@@ -2346,7 +2364,7 @@ const FieldMetaDataForm = ({
                             </div>
                           )}
                           {currentFields.includes("relationType") && (
-                            <div className="field mt-1 flex w-full items-center gap-2 px-2 pt-2">
+                            <div className="field mt-1 flex min-w-0 basis-full flex-col gap-2 px-2 pt-2 md:flex-row md:items-center">
                               {/* <label
                                   htmlFor="relationType"
                                   className="form-field-label"
@@ -2373,7 +2391,7 @@ const FieldMetaDataForm = ({
                               <label
                                 style={{ marginBottom: "0px" }}
                                 htmlFor="relationType"
-                                className={classNames("form-field-label", styles.fieldLabel)}
+                                className={classNames("form-field-label md:shrink-0", styles.fieldLabel)}
                               >
                                 Relation Type
                               </label>
@@ -2386,7 +2404,7 @@ const FieldMetaDataForm = ({
                                     formik.setFieldValue("relationCreateInverse", true);
                                   }
                                 }}
-                                className={classNames("", {
+                                className={classNames("solid-field-relation-type-control w-full min-w-0", {
                                   "is-invalid": isFormFieldValid(formik, "relationType"),
                                 })}
                               />
@@ -2397,7 +2415,7 @@ const FieldMetaDataForm = ({
                             </div>
                           )}
                           {currentFields.includes("relationType") && (formik.values.relationType === "many-to-one" || formik.values.relationType === "one-to-many") && (
-                            <div className="field mt-2 flex flex-col gap-2 px-2 pt-2 md:w-1/2">
+                            <div className="field mt-2 flex min-w-0 basis-full flex-col gap-2 px-2 pt-2 md:basis-1/2">
                               <label
                                 htmlFor="relationCascade"
                                 className={classNames("form-field-label", styles.fieldLabel)}
@@ -2430,7 +2448,7 @@ const FieldMetaDataForm = ({
                           )}
 
                           {currentFields.includes("relationModelModuleName") && (
-                            <div className="field mt-2 flex flex-col gap-2 px-2 pt-2 md:w-1/2">
+                            <div className="field mt-2 flex min-w-0 basis-full flex-col gap-2 px-2 pt-2 md:basis-1/2">
                               <label
                                 htmlFor="relationModelModuleName"
                                 className={classNames("form-field-label", styles.fieldLabel)}
@@ -2488,7 +2506,7 @@ const FieldMetaDataForm = ({
                           {currentFields.includes(
                             "relationCoModelSingularName"
                           ) && (
-                              <div className="field mt-2 flex flex-col gap-2 px-2 pt-2 md:w-1/2">
+                              <div className="field mt-2 flex min-w-0 basis-full flex-col gap-2 px-2 pt-2 md:basis-1/2">
                                 <label
                                   htmlFor="relationCoModelSingularName"
                                   className={classNames("form-field-label", styles.fieldLabel)}
@@ -2528,7 +2546,7 @@ const FieldMetaDataForm = ({
                               </div>
                             )}
                           {currentFields.includes("relationCoModelColumnName") && (formik.values.relationType === "many-to-many" || formik.values.relationType === "many-to-one") && (
-                            <div className="field mt-2 flex flex-col gap-2 px-2 pt-2 md:w-1/2">
+                            <div className="field mt-2 flex min-w-0 basis-full flex-col gap-2 px-2 pt-2 md:basis-1/2">
                               <label
                                 htmlFor="relationCoModelColumnName"
                                 className={classNames("form-field-label", styles.fieldLabel)}
@@ -2557,7 +2575,7 @@ const FieldMetaDataForm = ({
                             </div>
                           )}
                           {askForUserKeyField && (
-                            <div className="field mt-2 flex flex-col gap-2 px-2 pt-2 md:w-1/2">
+                            <div className="field mt-2 flex min-w-0 basis-full flex-col gap-2 px-2 pt-2 md:basis-1/2">
                               <label
                                 htmlFor="userKey"
                                 className={classNames("form-field-label", styles.fieldLabel)}
@@ -2594,7 +2612,7 @@ const FieldMetaDataForm = ({
                           {currentFields.includes(
                             "relationFieldFixedFilter"
                           ) && (
-                              <div className="field mt-2 flex flex-col gap-2 px-2 pt-2  md:w-1/2">
+                              <div className="field mt-2 flex min-w-0 basis-full flex-col gap-2 px-2 pt-2 md:basis-1/2">
                                 <label
                                   htmlFor="relationFieldFixedFilter"
                                   className={classNames("form-field-label", styles.fieldLabel)}
@@ -2640,7 +2658,7 @@ const FieldMetaDataForm = ({
                             )}
 
                           {currentFields.includes("relationCreateInverse") && (
-                            <div className="field mt-2 flex flex-col gap-2 px-2 pt-2 md:w-1/2">
+                            <div className="field mt-2 flex min-w-0 basis-full flex-col gap-2 px-2 pt-2 md:basis-1/2">
                               <label htmlFor="relationCreateInverse" className={classNames("form-field-label", styles.fieldLabel)}>
                                 Relation Create Inverse
                               </label>
@@ -2661,12 +2679,12 @@ const FieldMetaDataForm = ({
                           )}
 
                           {currentFields.includes("relationCoModelFieldName") && formik.values.relationCreateInverse && !formik.values.relationCoModelSingularName && (
-                            <div className="field mt-2 flex flex-col gap-2 px-2 pt-2 md:w-1/2">
+                            <div className="field mt-2 flex min-w-0 basis-full flex-col gap-2 px-2 pt-2 md:basis-1/2">
                               <SolidMessage text="Please select Co-model" />
                             </div>
                           )}
                           {currentFields.includes("relationCoModelFieldName") && formik.values.relationCreateInverse && formik.values.relationCoModelSingularName && (
-                            <div className="field mt-2 flex flex-col gap-2 px-2 pt-2 md:w-1/2">
+                            <div className="field mt-2 flex min-w-0 basis-full flex-col gap-2 px-2 pt-2 md:basis-1/2">
                               <label
                                 htmlFor="relationCoModelFieldName"
                                 className={classNames("form-field-label", styles.fieldLabel)}
@@ -2736,7 +2754,7 @@ const FieldMetaDataForm = ({
 
 
                           {currentFields.includes("relationJoinTableName") && formik.values.relationType === "many-to-many" && (
-                            <div className="field mt-2 flex flex-col gap-2 px-2 pt-2 md:w-1/2">
+                            <div className="field mt-2 flex min-w-0 basis-full flex-col gap-2 px-2 pt-2 md:basis-1/2">
                               <label
                                 htmlFor="relationJoinTableName"
                                 className={classNames("form-field-label", styles.fieldLabel)}
@@ -3087,7 +3105,7 @@ const FieldMetaDataForm = ({
                           <div className="flex flex-wrap -mx-2 -mt-2">
                             {(showRegexFields && selectedTypeValue === "password") &&
                               <>
-                                <div className="field mt-2 flex flex-col gap-2 px-2 pt-2 md:w-1/2">
+                                <div className="field mt-2 flex min-w-0 basis-full flex-col gap-2 px-2 pt-2 md:basis-1/2">
                                   <label
                                     htmlFor="regexPattern"
                                     className={classNames("form-field-label", styles.fieldLabel)}
@@ -3114,7 +3132,7 @@ const FieldMetaDataForm = ({
                             }
                             {showRegexFields && (
                               <>
-                                <div className="field mt-2 flex flex-col gap-2 px-2 pt-2 md:w-1/2">
+                                <div className="field mt-2 flex min-w-0 basis-full flex-col gap-2 px-2 pt-2 md:basis-1/2">
                                   <label
                                     htmlFor="regexPattern"
                                     className={classNames("form-field-label", styles.fieldLabel)}
@@ -3139,7 +3157,7 @@ const FieldMetaDataForm = ({
                                   )}
                                 </div>
                                 {showRegexFields && (
-                                  <div className="field mt-2 mb-3 flex flex-col gap-2 px-2 pt-2 md:mb-3 md:w-1/2">
+                                  <div className="field mt-2 mb-3 flex min-w-0 basis-full flex-col gap-2 px-2 pt-2 md:mb-3 md:basis-1/2">
                                     <label
                                       htmlFor="regexPatternNotMatchingErrorMsg"
                                       className={classNames("form-field-label", styles.fieldLabel)}
@@ -3170,7 +3188,7 @@ const FieldMetaDataForm = ({
                             {(showMinFields || showMaxFields) &&
                               <>
                                 {showMinFields && (
-                                  <div className="field mt-2 flex flex-col gap-2 px-2 pt-2 md:w-1/2">
+                                  <div className="field mt-2 flex min-w-0 basis-full flex-col gap-2 px-2 pt-2 md:basis-1/2">
                                     <label htmlFor="min" className={classNames("form-field-label", styles.fieldLabel)}>
                                       Min {(selectedTypeValue !== "int" && selectedTypeValue !== "decimal") && `(Characters Allowed)`}
 
@@ -3209,7 +3227,7 @@ const FieldMetaDataForm = ({
                                   </div>
                                 )}
                                 {showMaxFields && (
-                                  <div className="field mt-2 flex flex-col gap-2 px-2 pt-2 md:w-1/2">
+                                  <div className="field mt-2 flex min-w-0 basis-full flex-col gap-2 px-2 pt-2 md:basis-1/2">
                                     <label htmlFor="max" className={classNames("form-field-label", styles.fieldLabel)}>
                                       Max {(selectedTypeValue !== "int" &&
                                         selectedTypeValue !== "decimal") && `(Characters allowed)`}
@@ -3251,7 +3269,7 @@ const FieldMetaDataForm = ({
                               </>
                             }
                             {showOrmOptions && (
-                              <div className="field mt-2 flex flex-col gap-2 px-2 pt-2 md:w-1/2">
+                              <div className="field mt-2 flex min-w-0 basis-full flex-col gap-2 px-2 pt-2 md:basis-1/2">
                                 <label htmlFor="ormType" className={classNames("form-field-label", styles.fieldLabel)}>
                                   Type
                                 </label>

--- a/src/components/core/model/FieldMetaDataForm.tsx
+++ b/src/components/core/model/FieldMetaDataForm.tsx
@@ -199,7 +199,7 @@ const SelectionStaticValues = ({ enumValue, onUpdate, onDelete, onAdd }: any) =>
   };
 
   return (
-    <div className="mt-2 flex items-center gap-2">
+    <div className="solid-field-selection-static-row">
 
       {/* Input field for Value */}
       <SolidInput
@@ -2783,7 +2783,7 @@ const FieldMetaDataForm = ({
                           )}
 
                           {currentFields.includes("selectionDynamicProvider") && (
-                            <div className="field mt-2 flex flex-col gap-2 px-2 pt-2 md:w-1/2">
+                            <div className="field mt-2 flex min-w-0 basis-full flex-col gap-2 px-2 pt-2 md:basis-1/2">
                               <label
                                 htmlFor="selectionDynamicProvider"
                                 className={classNames("form-field-label", styles.fieldLabel)}
@@ -2839,7 +2839,7 @@ const FieldMetaDataForm = ({
                             </div>
                           )}
                           {currentFields.includes("selectionValueType") && (
-                            <div className="field mt-2 flex flex-col gap-2 px-2 pt-2 md:w-1/2">
+                            <div className="field mt-2 flex min-w-0 basis-full flex-col gap-2 px-2 pt-2 md:basis-1/2">
                               <label
                                 htmlFor="selectionValueType"
                                 className={classNames("form-field-label", styles.fieldLabel)}
@@ -2851,6 +2851,7 @@ const FieldMetaDataForm = ({
                                 options={selctionValueTypes}
                                 optionLabel="label"
                                 optionValue="value"
+                                native={false}
                                 onChange={({ value }) =>
                                   formik.setFieldValue(
                                     "selectionValueType",
@@ -2875,7 +2876,7 @@ const FieldMetaDataForm = ({
                           )}
 
                           {currentFields.includes("selectionStaticValues") && (
-                            <div className="field mt-2 flex flex-col gap-2 px-2 pt-2 md:w-1/2">
+                            <div className="field mt-2 flex min-w-0 basis-full flex-col gap-2 px-2 pt-2 md:basis-1/2">
                               <label
                                 htmlFor="selectionStaticValues"
                                 className={classNames("form-field-label", styles.fieldLabel)}

--- a/src/components/core/model/FieldMetaDataForm.tsx
+++ b/src/components/core/model/FieldMetaDataForm.tsx
@@ -3287,9 +3287,9 @@ const FieldMetaDataForm = ({
                       )}
 
                       {(formik.values.relationType !== "many-to-many" && formik.values.relationType !== "one-to-many") && <p className="form-wrapper-heading">Settings</p>}
-                      <div className="flex flex-wrap -mx-2 mt-2 md:mt-0">
+                      <div className="solid-field-settings-grid mt-2 md:mt-0">
                         {currentFields.includes("required") && (formik.values.relationType !== "many-to-many" && formik.values.relationType !== "one-to-many") && (
-                          <div className="field mt-2 flex w-1/2 flex-col gap-2 px-2 pt-2">
+                          <div className="field solid-field-settings-item">
                             <div className="solid-field-checkbox-row">
                               <SolidCheckbox
                                 id="required"
@@ -3315,7 +3315,7 @@ const FieldMetaDataForm = ({
                           </div>
                         )}
                         {currentFields.includes("unique") && selectedTypeValue !== 'relation' && (
-                          <div className="field flex w-1/2 flex-col gap-2 px-2 pt-2">
+                          <div className="field solid-field-settings-item">
                             <div className="solid-field-checkbox-row">
                               <SolidCheckbox
                                 id="unique"
@@ -3349,7 +3349,7 @@ const FieldMetaDataForm = ({
                           </div>
                         )}
                         {currentFields.includes("index") && selectedTypeValue !== 'relation' && (
-                          <div className="field mt-2 flex w-1/2 flex-col gap-2 px-2 pt-2">
+                          <div className="field solid-field-settings-item">
                             <div className="solid-field-checkbox-row">
                               <SolidCheckbox
                                 id="index"
@@ -3369,7 +3369,7 @@ const FieldMetaDataForm = ({
                           </div>
                         )}
                         {currentFields.includes("private") && selectedTypeValue !== 'relation' && (
-                          <div className="field mt-2 flex w-1/2 flex-col gap-2 px-2 pt-2">
+                          <div className="field solid-field-settings-item">
                             <div className="solid-field-checkbox-row">
                               <SolidCheckbox
                                 id="private"
@@ -3392,7 +3392,7 @@ const FieldMetaDataForm = ({
                           </div>
                         )}
                         {currentFields.includes("encrypt") && selectedTypeValue !== 'relation' && (
-                          <div className="field mt-2 flex w-1/2 flex-col gap-2 px-2 pt-2">
+                          <div className="field solid-field-settings-item">
                             <div className="solid-field-checkbox-row">
                               <SolidCheckbox
                                 id="encrypt"
@@ -3413,7 +3413,7 @@ const FieldMetaDataForm = ({
                           </div>
                         )}
                         {currentFields.includes("isMultiSelect") && (
-                          <div className="field mt-2 flex w-1/2 flex-col gap-2 px-2 pt-2">
+                          <div className="field solid-field-settings-item">
                             <div className="solid-field-checkbox-row">
                               <SolidCheckbox
                                 id="isMultiSelect"
@@ -3433,7 +3433,7 @@ const FieldMetaDataForm = ({
                           </div>
                         )}
                         {currentFields.includes("enableAuditTracking") && formik.values.relationType !== "one-to-many" && (
-                          <div className="field mt-2 flex w-1/2 flex-col gap-2 px-2 pt-2">
+                          <div className="field solid-field-settings-item">
                             <div className="solid-field-checkbox-row">
                               <SolidCheckbox
                                 id="enableAuditTracking"
@@ -3455,7 +3455,7 @@ const FieldMetaDataForm = ({
                           </div>
                         )}
                         {currentFields.includes("isUserKey") && formik.values.unique && (
-                          <div className="field mt-2 flex w-1/2 flex-col gap-2 px-2 pt-2">
+                          <div className="field solid-field-settings-item">
                             <div className="solid-field-checkbox-row">
                               <SolidCheckbox
                                 id="isUserKey"
@@ -3477,7 +3477,7 @@ const FieldMetaDataForm = ({
                           </div>
                         )}
                         {currentFields.includes("isPrimaryKey") && modelMetaData?.isLegacyTable && (
-                          <div className="field mt-2 flex w-1/2 flex-col gap-2 px-2 pt-2">
+                          <div className="field solid-field-settings-item">
                             <div className="flex items-center gap-2">
                               <SolidCheckbox
                                 id="isPrimaryKey"

--- a/src/components/core/module/ModuleMetadataExplorer.css
+++ b/src/components/core/module/ModuleMetadataExplorer.css
@@ -754,6 +754,35 @@
 
 
 @media (max-width: 640px) {
+  .solid-module-explorer-panel {
+    overflow-y: auto;
+  }
+
+  .solid-module-explorer-workspace {
+    display: flex;
+    flex-direction: column;
+    height: auto;
+  }
+
+  .solid-module-explorer-sidebar {
+    max-height: 16rem;
+    flex: 0 0 auto;
+  }
+
+  .solid-module-explorer-main {
+    height: auto;
+    overflow: visible;
+  }
+
+  .solid-module-explorer-jsoneditor .jsoneditor-menu a.jsoneditor-poweredBy {
+    display: none;
+  }
+
+  .solid-module-explorer-jsoneditor div.jsoneditor-outer.has-main-menu-bar {
+    margin-top: 0;
+    padding-top: 0;
+  }
+
   .solid-module-explorer-main-header {
     flex-direction: column;
     align-items: stretch;

--- a/src/components/core/module/ModuleMetadataExplorer.css
+++ b/src/components/core/module/ModuleMetadataExplorer.css
@@ -747,7 +747,40 @@
 
 
 @media (max-width: 640px) {
-  .solid-module-explorer-main-actions{
-    gap: 0;
+  .solid-module-explorer-main-header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.65rem;
+    padding: 0.75rem;
+  }
+
+  .solid-module-explorer-main-title {
+    width: 100%;
+  }
+
+  .solid-module-explorer-main-heading-row {
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.2rem 0.5rem;
+  }
+
+  .solid-module-explorer-main-title h4 {
+    white-space: normal;
+  }
+
+  .solid-module-explorer-inline-validation {
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
+  .solid-module-explorer-main-actions {
+    width: 100%;
+    justify-content: flex-start;
+    gap: 0.5rem;
+  }
+
+  .solid-module-explorer-main-meta {
+    flex: 1 0 100%;
+    min-width: 0;
   }
 }

--- a/src/components/core/module/ModuleMetadataExplorer.css
+++ b/src/components/core/module/ModuleMetadataExplorer.css
@@ -733,15 +733,22 @@
 @media (max-width: 1200px) {
   .solid-module-explorer-workspace {
     grid-template-columns: 1fr !important;
+    grid-template-rows: minmax(12rem, 38%) minmax(0, 1fr);
+    min-height: 0;
   }
 
   .solid-module-explorer-sidebar {
     border-right: none;
     border-bottom: 1px solid color-mix(in srgb, var(--border) 84%, transparent);
+    overflow: hidden;
   }
 
   .solid-module-explorer-resizer {
     display: none;
+  }
+
+  .solid-module-explorer-main {
+    overflow-y: auto;
   }
 }
 

--- a/src/components/core/module/ModuleMetadataExplorer.css
+++ b/src/components/core/module/ModuleMetadataExplorer.css
@@ -249,6 +249,7 @@
   min-width: 0;
   min-height: 0;
   height: 100%;
+  overflow-y: scroll;
 }
 
 .solid-module-explorer-main-header {


### PR DESCRIPTION
- Alignment issue in General tab under Settings
- Alignment issue in OAuth Settings section
- Explorer tab does not allow scrolling in module only
- Alignment issue in Explorer JSON editor footer
- Checkboxes and their helper text are vertically misaligned in Field form 
- Validation error message is misaligned in Add  Field form 
- Validation error messages are misaligned in Add  Field form 
- Alignment issue in section of Static Selection Field 
- Alignment issues with Settings, Save Section button, and “Powered by” text in Menu Item Metadata - patched
- Country field width is not consistent with State field 
- Validation error messages are misaligned in Add Book form 
- Locale dropdown is rendered outside the viewport