### PR TITLE
fix: prevent stale action response from affecting breadcrumb display

### DIFF
--- a/src/components/layout/AdminTopHeader.tsx
+++ b/src/components/layout/AdminTopHeader.tsx
@@ -53,7 +53,8 @@ export const AdminTopHeader = () => {
       const viewName = segments[4];
       const next = [
         moduleName ? toLabel(moduleName) : null,
-        modelFromApi ? decodeURIComponent(modelFromApi) : modelName ? toLabel(modelName) : null,
+        // After browser Back, the previous action response may still be cached; use it only when it belongs to this URL.
+        hasMatchingActionData && modelFromApi ? decodeURIComponent(modelFromApi) : modelName ? toLabel(modelName) : null,
         viewName ? toLabel(viewName) : null,
       ].filter(Boolean) as string[];
       return next.length ? next : ["Admin"];


### PR DESCRIPTION
Fixed stale breadcrumb labels after browser Back navigation. Breadcrumbs now validate cached action metadata against the current route and fall back to the URL-derived model name when it does not match.