### PR TITLE
Restore multiple saved filters (revert revert of #210)

### DIFF
--- a/src/components/core/card/SolidCardView.tsx
+++ b/src/components/core/card/SolidCardView.tsx
@@ -52,6 +52,7 @@ type SolidCardFilterInput = {
   custom_filter_predicate?: any;
   search_predicate?: any;
   saved_filter_predicate?: any;
+  saved_filter_items?: any[];
   predefined_search_predicate?: any;
 };
 
@@ -423,6 +424,7 @@ export const SolidCardView = forwardRef<SolidCardViewHandle, SolidCardViewParams
       saved_filter_id: filterPredicates.saved_filter_id || null,
       saved_filter_system_key: filterPredicates.saved_filter_system_key || null,
       saved_filter_name: filterPredicates.saved_filter_name || null,
+      saved_filter_items: filterPredicates.saved_filter_items || [],
       predefined_search_predicate: filterPredicates.predefined_search_predicate || {},
       predefined_search_chip: filterPredicates.predefined_search_chip || null,
     });
@@ -593,6 +595,7 @@ export const SolidCardView = forwardRef<SolidCardViewHandle, SolidCardViewParams
                     viewData={solidCardViewMetaDataResponse}
                     handleApplyCustomFilter={handleApplyCustomFilter}
                     filterPredicates={filterPredicates}
+                    allowMultipleSavedFilters
                   />
                 </div>
               </div>

--- a/src/components/core/common/SolidGlobalSearchElement.tsx
+++ b/src/components/core/common/SolidGlobalSearchElement.tsx
@@ -420,10 +420,12 @@ export const mergeAllDiffFilters = (customFilter: any, searchFilter: any, savedF
     return filters;
 }
 
-const SavedFilterList = ({ savedfilter, activeSavedFilterReference, applySavedFilter, openSavedCustomFilter, setSavedFilterTobeDeleted, setIsDeleteSQDialogVisible, isFocused, onMouseEnter, optionId }: any) => {
-    const isActive = savedfilter?.systemKey
-        ? activeSavedFilterReference === savedfilter.systemKey
-        : String(activeSavedFilterReference) === String(savedfilter.id);
+const SavedFilterList = ({ savedfilter, activeSavedFilterReference, activeSavedFilterReferences, applySavedFilter, openSavedCustomFilter, setSavedFilterTobeDeleted, setIsDeleteSQDialogVisible, isFocused, onMouseEnter, optionId }: any) => {
+    const isActive = activeSavedFilterReferences
+        ? activeSavedFilterReferences.includes(savedfilter?.systemKey ? `system:${savedfilter.systemKey}` : `id:${savedfilter.id}`)
+        : savedfilter?.systemKey
+            ? activeSavedFilterReference === savedfilter.systemKey
+            : String(activeSavedFilterReference) === String(savedfilter.id);
 
     return (
         <div className="solid-saved-filter-item" onMouseEnter={onMouseEnter}>
@@ -438,6 +440,10 @@ const SavedFilterList = ({ savedfilter, activeSavedFilterReference, applySavedFi
                     aria-label={`${savedfilter.name}${isActive ? ", applied" : ""}`}
                     onMouseDown={(e) => {
                         e.preventDefault();
+                        e.stopPropagation();
+                    }}
+                    onClick={(e) => {
+                        e.stopPropagation();
                         applySavedFilter(savedfilter);
                     }}
                     title={savedfilter?.description}
@@ -573,7 +579,7 @@ type RelationCache = Map<string, { label: string; value: number }>;
 
 
 
-export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handleApplyCustomFilter, showSaveFilterPopup, setShowSaveFilterPopup, filterPredicates }: any, ref) => {
+export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handleApplyCustomFilter, showSaveFilterPopup, setShowSaveFilterPopup, filterPredicates, allowMultipleSavedFilters = false }: any, ref) => {
     const dispatch = useDispatch();
     type OverlayOption =
         | { id: string; kind: "field"; field: any }
@@ -684,6 +690,8 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
     const [currentSavedFilterQuery, setCurrentSavedFilterQuery] = useState<any>();
     const [currentSavedFilterVariables, setCurrentSavedFilterVariables] = useState<Record<string, any>>({});
     const [currentSavedFilterRules, setCurrentSavedFilterRules] = useState<any>();
+    const [activeSavedFilters, setActiveSavedFilters] = useState<any[]>([]);
+    const [editingSavedFilterKey, setEditingSavedFilterKey] = useState<string | null>(null);
     const [showSavedFilterComponent, setShowSavedFilterComponent] = useState<boolean>(false);
 
 
@@ -837,6 +845,27 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
         viewData?.data?.solidView?.model?.id,
         user?.id
     ])
+
+    const getSavedFilterKey = (savedFilter: any) =>
+        savedFilter?.systemKey ? `system:${savedFilter.systemKey}` : `id:${savedFilter?.id}`;
+
+    const getPersistedSavedFilterItems = (queryObject: any): any[] => {
+        if (!allowMultipleSavedFilters) return [];
+        if (Array.isArray(queryObject?.saved_filter_items)) {
+            return queryObject.saved_filter_items;
+        }
+        if (queryObject?.saved_filter_predicate) {
+            return [{
+                id: queryObject.saved_filter_id,
+                systemKey: queryObject.saved_filter_system_key,
+                name: queryObject.saved_filter_name || "Saved Filter",
+                predicate: queryObject.saved_filter_predicate,
+                variables: queryObject.saved_filter_variables || {},
+            }];
+        }
+        return [];
+    };
+
 // Updates search, custom filter, grouping, aggregation, and UI state from a single shared filter source.
     const syncFilterUiStateFromSharedSource = useCallback(async (queryObject: any | null) => {
         const nextSearchFilter = queryObject?.search_predicate || null;
@@ -850,9 +879,33 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
             nextPredefinedBaseFilter && queryObject?.predefined_search_chip
                 ? queryObject.predefined_search_chip
                 : null;
-        const nextSavedFilter = queryObject?.saved_filter_predicate || null;
+        const persistedSavedFilterItems = getPersistedSavedFilterItems(queryObject);
+        const nextSavedFilterItems = allowMultipleSavedFilters
+            ? persistedSavedFilterItems.map((item: any) => {
+                const savedFilter = availableSavedFilters.find((candidate: any) =>
+                    item?.systemKey
+                        ? candidate?.systemKey === item.systemKey
+                        : String(candidate?.id) === String(item?.id)
+                );
+                return {
+                    data: savedFilter || {
+                        id: item?.id,
+                        systemKey: item?.systemKey,
+                        name: item?.name || "Saved Filter",
+                        filterQueryJson: JSON.stringify(item?.predicate || {}),
+                    },
+                    query: item?.predicate || {},
+                    variables: item?.variables || {},
+                };
+            })
+            : [];
+        const nextSavedFilter = allowMultipleSavedFilters
+            ? (nextSavedFilterItems.length > 0 ? { $or: nextSavedFilterItems.map((item: any) => item.query) } : null)
+            : queryObject?.saved_filter_predicate || null;
         const nextSavedFilterVariables = queryObject?.saved_filter_variables ?? {};
-        const nextSavedFilterData = nextSavedFilter
+        const nextSavedFilterData = allowMultipleSavedFilters
+            ? (nextSavedFilterItems.length > 0 ? nextSavedFilterItems[nextSavedFilterItems.length - 1].data : null)
+            : nextSavedFilter
             ? availableSavedFilters.find((savedFilter: any) => {
                 if (queryObject?.saved_filter_system_key) {
                     return savedFilter?.systemKey === queryObject.saved_filter_system_key;
@@ -877,6 +930,7 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
         setCurrentSavedFilterData((prev: any) => areFilterStateValuesEqual(prev, nextSavedFilterData) ? prev : nextSavedFilterData);
         setCurrentSavedFilterQuery((prev: any) => areFilterStateValuesEqual(prev, nextSavedFilter) ? prev : nextSavedFilter);
         setCurrentSavedFilterVariables((prev) => areFilterStateValuesEqual(prev, nextSavedFilterVariables) ? prev : nextSavedFilterVariables);
+        setActiveSavedFilters((prev) => areFilterStateValuesEqual(prev, nextSavedFilterItems) ? prev : nextSavedFilterItems);
 
         if (nextCustomFilter && viewData?.data) {
             const rules: FilterRule = transformFiltersToRules(nextCustomFilter);
@@ -912,7 +966,7 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
 
         setGroupingRules((prev) => areFilterStateValuesEqual(prev, nextGroupingRules) ? prev : nextGroupingRules);
         setAggregationRules((prev) => areFilterStateValuesEqual(prev, nextAggregationRules) ? prev : nextAggregationRules);
-    }, [availableSavedFilters, initialState, viewData]);
+    }, [allowMultipleSavedFilters, availableSavedFilters, initialState, viewData]);
 
     const resetAppliedFilters = ({ preserveGrouping = false }: { preserveGrouping?: boolean } = {}) => {
         setSearchChips([]);
@@ -925,6 +979,8 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
         setCurrentSavedFilterQuery(null);
         setCurrentSavedFilterVariables({});
         setCurrentSavedFilterRules(null);
+        setActiveSavedFilters([]);
+        setEditingSavedFilterKey(null);
         if (!preserveGrouping) {
             setGroupingRules(defaultGroupingRules);
             setAggregationRules(defaultAggregationRules);
@@ -1224,6 +1280,15 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
         //     };
         // }
         setCurrentSavedFilterQuery(finalCustomFilter);
+        if (allowMultipleSavedFilters && editingSavedFilterKey) {
+            const nextItems = activeSavedFilters.map((item: any) =>
+                getSavedFilterKey(item.data) === editingSavedFilterKey
+                    ? { ...item, query: finalCustomFilter }
+                    : item
+            );
+            setActiveSavedFilters(nextItems);
+            persistActiveSavedFilters(nextItems);
+        }
         setShowSavedFilterComponent(false);
         setHasSearched(true)
         setRefreshKey((prev) => prev + 1)
@@ -1265,7 +1330,9 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
             const finalSearchFilter = tranformSearchToFilters(formattedChips);
             setSearchFilter(finalSearchFilter);
 
-            let finalSavedFilter: any = currentSavedFilterQuery
+            const finalSavedFilter: any = allowMultipleSavedFilters
+                ? (activeSavedFilters.length > 0 ? { $or: activeSavedFilters.map((item: any) => item.query) } : null)
+                : currentSavedFilterQuery;
             const finalPredefinedFilter = predefinedSearchBaseFilter
 
             const finalCustomFilter = customFilter
@@ -1274,19 +1341,31 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
                 finalPredefinedFilter && predefinedSearchChip
                     ? predefinedSearchChip
                     : null;
-            if (finalSavedFilter && Object.keys(finalSavedFilter).length > 0) {
+            if (allowMultipleSavedFilters && activeSavedFilters.length > 0) {
+                const resolvedItems = activeSavedFilters.map((item: any) => resolveSavedFilterVariables(item.query, user?.id, item.variables || {}));
+                if (resolvedItems.some((item: any) => item.missingVariables.length > 0)) return;
+                finalFilter.resolved_saved_filter_predicate = { $or: resolvedItems.map((item: any) => item.value) };
+                finalFilter.saved_filter_variables = {};
+                finalFilter.saved_filter_items = activeSavedFilters.map((item: any) => ({
+                    id: item.data?.id ?? null,
+                    systemKey: item.data?.systemKey ?? null,
+                    name: item.data?.name ?? null,
+                    predicate: item.query,
+                    variables: item.variables || {},
+                }));
+            } else if (finalSavedFilter && Object.keys(finalSavedFilter).length > 0) {
                 const resolved = resolveSavedFilterVariables(finalSavedFilter, user?.id, currentSavedFilterVariables);
                 if (resolved.missingVariables.length > 0) return;
                 finalFilter.resolved_saved_filter_predicate = resolved.value;
                 finalFilter.saved_filter_variables = currentSavedFilterVariables;
             }
-            if (currentSavedFilterData?.id) {
+            if (!allowMultipleSavedFilters && currentSavedFilterData?.id) {
                 finalFilter.saved_filter_id = currentSavedFilterData.id;
             }
-            if (currentSavedFilterData?.systemKey) {
+            if (!allowMultipleSavedFilters && currentSavedFilterData?.systemKey) {
                 finalFilter.saved_filter_system_key = currentSavedFilterData.systemKey;
             }
-            if (currentSavedFilterData?.name) {
+            if (!allowMultipleSavedFilters && currentSavedFilterData?.name) {
                 finalFilter.saved_filter_name = currentSavedFilterData.name;
             }
             handleApplyCustomFilter(finalFilter, true);
@@ -1318,16 +1397,19 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
         // }
 
 
-        setSearchChips([]);
-        setSearchFilter(null);
-        setFilterRules(initialState);
-        setCustomFilter(null)
-        setPredefinedSearchChip(null);
-        setPredefinedSearchBaseFilter(null);
+        if (!allowMultipleSavedFilters) {
+            setSearchChips([]);
+            setSearchFilter(null);
+            setFilterRules(initialState);
+            setCustomFilter(null)
+            setPredefinedSearchChip(null);
+            setPredefinedSearchBaseFilter(null);
+        }
 
         if (savedfilter?.id) {
             const savedfilterId = savedfilter.id;
             setShowOverlay(false);
+            setEditingSavedFilterKey(getSavedFilterKey(savedfilter));
             const currentSavedFilterData: any = availableSavedFilters.find((savedFilter: any) => savedFilter.id === savedfilterId);
             setCurrentSavedFilterData(currentSavedFilterData);
             if (currentSavedFilterData) {
@@ -1349,7 +1431,32 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
         }
     }
 
+    const persistActiveSavedFilters = (items: any[]) => {
+        const first = items[0];
+        const persistedFilter = {
+            ...(getFilterObjectFromLocalStorage() || {}),
+            saved_filter_items: items.map((item) => ({
+                id: item.data?.id ?? null,
+                systemKey: item.data?.systemKey ?? null,
+                name: item.data?.name ?? null,
+                predicate: item.query,
+                variables: item.variables || {},
+            })),
+            saved_filter_predicate: items.length > 0 ? (items.length === 1 ? first.query : { $or: items.map((item) => item.query) }) : null,
+            saved_filter_variables: items.length === 1 ? (first.variables || {}) : {},
+            saved_filter_id: items.length === 1 ? first.data?.id ?? null : null,
+            saved_filter_system_key: items.length === 1 ? first.data?.systemKey ?? null : null,
+            saved_filter_name: items.length === 1 ? first.data?.name ?? null : null,
+        };
+        delete persistedFilter.finalFullFilter;
+        setFilterObjectToLocalStorage(persistedFilter);
+    };
+
     const persistActiveSavedFilter = (savedFilter: any, filterJson: any, variables: Record<string, any>) => {
+        if (allowMultipleSavedFilters) {
+            persistActiveSavedFilters([{ data: savedFilter, query: filterJson, variables }]);
+            return;
+        }
         const persistedFilter = {
             ...(getFilterObjectFromLocalStorage() || {}),
             custom_filter_predicate: null,
@@ -1375,6 +1482,7 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
 
         const persistedFilter = {
             ...(getFilterObjectFromLocalStorage() || {}),
+            saved_filter_items: [],
             saved_filter_predicate: null,
             saved_filter_variables: {},
             saved_filter_id: null,
@@ -1397,8 +1505,19 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
                 detail: ERROR_MESSAGES.ENTITY_DELETE,
             }));
 
-            if (String(savedFilterTobeDeleted) === String(currentSavedFilterData?.id)) {
-                clearActiveSavedFilter();
+            if (allowMultipleSavedFilters) {
+                const nextItems = activeSavedFilters.filter((item: any) => String(item.data?.id) !== String(savedFilterTobeDeleted));
+                setActiveSavedFilters(nextItems);
+                if (String(savedFilterTobeDeleted) === String(currentSavedFilterData?.id)) {
+                    setCurrentSavedFilterData(null);
+                    setCurrentSavedFilterQuery(null);
+                    setCurrentSavedFilterVariables({});
+                }
+                persistActiveSavedFilters(nextItems);
+                setHasSearched(true);
+                setRefreshKey((prev) => prev + 1);
+            } else if (String(savedFilterTobeDeleted) === String(currentSavedFilterData?.id)) {
+                removeSavedFilter();
             }
             setIsDeleteSQDialogVisible(false);
             setTimeout(() => {
@@ -1434,12 +1553,14 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
                     detail: ERROR_MESSAGES.SAVED_FILTER_UPDATED_SUCCESSFULLY,
                 }));
 
-                setSearchChips([]);
-                setSearchFilter(null);
-                setFilterRules(initialState);
-                setCustomFilter(null)
-                setPredefinedSearchChip(null);
-                setPredefinedSearchBaseFilter(null);
+                if (!allowMultipleSavedFilters) {
+                    setSearchChips([]);
+                    setSearchFilter(null);
+                    setFilterRules(initialState);
+                    setCustomFilter(null)
+                    setPredefinedSearchChip(null);
+                    setPredefinedSearchBaseFilter(null);
+                }
                 // Apply the rename immediately, both to the active filter and to
                 // the cached list — otherwise the list still holds the pre-rename
                 // entry, which wins the id-based lookup the next time saved-filter
@@ -1449,7 +1570,17 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
                 setSavedFilters((prev) => prev.map((f: any) => String(f?.id) === String(formValues.id) ? { ...f, ...savedFilterRecord } : f));
                 setCurrentSavedFilterData(savedFilterRecord);
                 setCurrentSavedFilterQuery(filterJson);
-                persistActiveSavedFilter(savedFilterRecord, filterJson, currentSavedFilterVariables);
+                if (allowMultipleSavedFilters) {
+                    const nextItems = activeSavedFilters.map((item: any) =>
+                        getSavedFilterKey(item.data) === getSavedFilterKey(savedFilterRecord)
+                            ? { data: savedFilterRecord, query: filterJson, variables: currentSavedFilterVariables }
+                            : item
+                    );
+                    setActiveSavedFilters(nextItems);
+                    persistActiveSavedFilters(nextItems);
+                } else {
+                    persistActiveSavedFilter(savedFilterRecord, filterJson, currentSavedFilterVariables);
+                }
                 setHasSearched(true);
                 setRefreshKey((prev) => prev + 1);
             } else {
@@ -1469,12 +1600,14 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
                     detail: ERROR_MESSAGES.SAVED_FILTER_CREATED_SUCCESSFULLY,
                 }));
 
-                setSearchChips([]);
-                setSearchFilter(null);
-                setFilterRules(initialState);
-                setCustomFilter(null)
-                setPredefinedSearchChip(null);
-                setPredefinedSearchBaseFilter(null);
+                if (!allowMultipleSavedFilters) {
+                    setSearchChips([]);
+                    setSearchFilter(null);
+                    setFilterRules(initialState);
+                    setCustomFilter(null)
+                    setPredefinedSearchChip(null);
+                    setPredefinedSearchBaseFilter(null);
+                }
                 // The custom filter just became this saved filter — apply it, and
                 // seed the cached list with it, immediately (see rename branch above).
                 const savedFilterRecord = { id: result.data.id, name: formValues.name, isPrivate: formValues.isPrivate, filterQueryJson: JSON.stringify(filterJson, null, 2) };
@@ -1482,7 +1615,13 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
                 setCurrentSavedFilterData(savedFilterRecord);
                 setCurrentSavedFilterQuery(filterJson);
                 setCurrentSavedFilterVariables({});
-                persistActiveSavedFilter(savedFilterRecord, filterJson, {});
+                if (allowMultipleSavedFilters) {
+                    const nextItems = [...activeSavedFilters, { data: savedFilterRecord, query: filterJson, variables: {} }];
+                    setActiveSavedFilters(nextItems);
+                    persistActiveSavedFilters(nextItems);
+                } else {
+                    persistActiveSavedFilter(savedFilterRecord, filterJson, {});
+                }
                 setHasSearched(true);
                 setRefreshKey((prev) => prev + 1);
             }
@@ -1585,6 +1724,28 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
             return false;
         }
 
+        if (allowMultipleSavedFilters) {
+            const key = getSavedFilterKey(savedfilter);
+            const nextItem = { data: savedfilter, query: filterJson, variables };
+            const existingItem = activeSavedFilters.find((item: any) => getSavedFilterKey(item.data) === key);
+            if (existingItem && areFilterStateValuesEqual(existingItem.query, filterJson) && areFilterStateValuesEqual(existingItem.variables, variables)) {
+                return true;
+            }
+            const nextItems = existingItem
+                ? activeSavedFilters.map((item: any) => getSavedFilterKey(item.data) === key ? nextItem : item)
+                : [...activeSavedFilters, nextItem];
+            setActiveSavedFilters(nextItems);
+            setCurrentSavedFilterData(savedfilter);
+            setCurrentSavedFilterQuery(filterJson);
+            setCurrentSavedFilterVariables(variables);
+            setEditingSavedFilterKey(null);
+            persistActiveSavedFilters(nextItems);
+            setShowOverlay(false);
+            setHasSearched(true);
+            setRefreshKey((prev) => prev + 1);
+            return true;
+        }
+
         // Applying the already-active filter must be a no-op. This is important
         // for lifecycle extensions: applying a filter causes a new list load,
         // which invokes onBeforeListDataLoad/onListLoad again.
@@ -1621,6 +1782,19 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
     }
 
     const removeSavedFilter = () => {
+        if (allowMultipleSavedFilters) {
+            const key = getSavedFilterKey(currentSavedFilterData);
+            const nextItems = activeSavedFilters.filter((item: any) => getSavedFilterKey(item.data) !== key);
+            setActiveSavedFilters(nextItems);
+            setCurrentSavedFilterData(null);
+            setCurrentSavedFilterQuery(null);
+            setCurrentSavedFilterVariables({});
+            setEditingSavedFilterKey(null);
+            persistActiveSavedFilters(nextItems);
+            setHasSearched(true);
+            setRefreshKey((prev) => prev + 1);
+            return;
+        }
         clearActiveSavedFilter();
     }
 
@@ -1730,14 +1904,35 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
     const managedChipItems = useMemo<ManagedChipItem[]>(() => {
         const items: ManagedChipItem[] = [];
 
-        if (currentSavedFilterData?.name) {
-            items.push({
-                id: "saved-filter",
-                type: "saved",
-                label: `Saved: ${currentSavedFilterData.name}`,
-                onRemove: () => removeSavedFilter(),
-            });
-        }
+        const savedItems = allowMultipleSavedFilters
+            ? activeSavedFilters
+            : (currentSavedFilterData?.name ? [{ data: currentSavedFilterData }] : []);
+        savedItems.forEach((item: any) => {
+            if (item.data?.name) {
+                items.push({
+                    id: `saved-filter:${getSavedFilterKey(item.data)}`,
+                    type: "saved",
+                    label: `Saved: ${item.data.name}`,
+                    onRemove: () => {
+                        if (!allowMultipleSavedFilters) {
+                            removeSavedFilter();
+                            return;
+                        }
+                        const nextItems = activeSavedFilters.filter((active: any) => getSavedFilterKey(active.data) !== getSavedFilterKey(item.data));
+                        setActiveSavedFilters(nextItems);
+                        if (getSavedFilterKey(currentSavedFilterData) === getSavedFilterKey(item.data)) {
+                            setCurrentSavedFilterData(null);
+                            setCurrentSavedFilterQuery(null);
+                            setCurrentSavedFilterVariables({});
+                        }
+                        persistActiveSavedFilters(nextItems);
+                        setHasSearched(true);
+                        setRefreshKey((prev) => prev + 1);
+                    },
+                    ...(allowMultipleSavedFilters ? { onOpen: () => openSavedCustomFilter(item.data) } : {}),
+                });
+            }
+        });
 
         if (predefinedSearchChip?.name && predefinedSearchChip?.value) {
             items.push({
@@ -1783,6 +1978,8 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
         return items;
     }, [
         currentSavedFilterData,
+        activeSavedFilters,
+        allowMultipleSavedFilters,
         predefinedSearchChip,
         customFilter,
         customRuleCount,
@@ -2019,7 +2216,6 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
     const removePredefinedSearchChip = () => {
         setPredefinedSearchChip(null);
         setPredefinedSearchBaseFilter(null)
-        setCustomFilter(null);
         setHasSearched(true);
         setRefreshKey((prev) => prev + 1)
     };
@@ -2224,6 +2420,10 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
                                                             className={`text-color solid-search-overlay-option ${focusedIndex === optionIndex ? "solid-search-overlay-option-active" : ""}`}
                                                             onMouseDown={(e) => {
                                                                 e.preventDefault();
+                                                                e.stopPropagation();
+                                                            }}
+                                                            onClick={(e) => {
+                                                                e.stopPropagation();
                                                                 handlePredefinedSearch(predefinedSearch);
                                                             }}
                                                             onMouseEnter={() => setFocusedIndex(optionIndex)}
@@ -2266,6 +2466,10 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
                                                         className={`text-color solid-search-overlay-option ${focusedIndex === optionIndex ? "solid-search-overlay-option-active" : ""}`}
                                                         onMouseDown={(e) => {
                                                             e.preventDefault();
+                                                            e.stopPropagation();
+                                                        }}
+                                                        onClick={(e) => {
+                                                            e.stopPropagation();
                                                             const currentValue = inputValue?.trim();
                                                             if (currentValue) {
                                                                 const values = currentValue.split(",").map((v) => v.trim()).filter((v) => v !== "");
@@ -2349,6 +2553,7 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
                                                     key={savedfilter.id}
                                                     savedfilter={savedfilter}
                                                     activeSavedFilterReference={currentSavedFilterData?.systemKey || currentSavedFilterData?.id}
+                                                    activeSavedFilterReferences={allowMultipleSavedFilters ? activeSavedFilters.map((item: any) => getSavedFilterKey(item.data)) : undefined}
                                                     applySavedFilter={applySavedFilter}
                                                     openSavedCustomFilter={openSavedCustomFilter}
                                                     setSavedFilterTobeDeleted={setSavedFilterTobeDeleted}

--- a/src/components/core/common/SolidGlobalSearchElement.tsx
+++ b/src/components/core/common/SolidGlobalSearchElement.tsx
@@ -1600,23 +1600,24 @@ export const SolidGlobalSearchElement = forwardRef(({ viewData, viewType, handle
                     detail: ERROR_MESSAGES.SAVED_FILTER_CREATED_SUCCESSFULLY,
                 }));
 
-                if (!allowMultipleSavedFilters) {
-                    setSearchChips([]);
-                    setSearchFilter(null);
-                    setFilterRules(initialState);
-                    setCustomFilter(null)
-                    setPredefinedSearchChip(null);
-                    setPredefinedSearchBaseFilter(null);
-                }
+                setSearchChips([]);
+                setSearchFilter(null);
+                setFilterRules(initialState);
+                setCustomFilter(null)
+                setPredefinedSearchChip(null);
+                setPredefinedSearchBaseFilter(null);
                 // The custom filter just became this saved filter — apply it, and
                 // seed the cached list with it, immediately (see rename branch above).
+                // A newly created saved filter replaces any other active filters/saved
+                // filters rather than joining them — only applying an existing saved
+                // filter is additive when allowMultipleSavedFilters is on.
                 const savedFilterRecord = { id: result.data.id, name: formValues.name, isPrivate: formValues.isPrivate, filterQueryJson: JSON.stringify(filterJson, null, 2) };
                 setSavedFilters((prev) => [savedFilterRecord, ...prev]);
                 setCurrentSavedFilterData(savedFilterRecord);
                 setCurrentSavedFilterQuery(filterJson);
                 setCurrentSavedFilterVariables({});
                 if (allowMultipleSavedFilters) {
-                    const nextItems = [...activeSavedFilters, { data: savedFilterRecord, query: filterJson, variables: {} }];
+                    const nextItems = [{ data: savedFilterRecord, query: filterJson, variables: {} }];
                     setActiveSavedFilters(nextItems);
                     persistActiveSavedFilters(nextItems);
                 } else {

--- a/src/components/core/kanban/SolidKanbanView.tsx
+++ b/src/components/core/kanban/SolidKanbanView.tsx
@@ -59,6 +59,7 @@ type SolidKanbanFilterInput = {
   custom_filter_predicate?: any;
   search_predicate?: any;
   saved_filter_predicate?: any;
+  saved_filter_items?: any[];
   predefined_search_predicate?: any;
 };
 
@@ -1073,6 +1074,8 @@ export const SolidKanbanView = forwardRef<SolidKanbanViewHandle, SolidKanbanView
         // @ts-ignore
         urlData.saved_filter_name = customFilter.saved_filter_name || null;
         // @ts-ignore
+        urlData.saved_filter_items = customFilter.saved_filter_items || [];
+        // @ts-ignore
         urlData.predefined_search_predicate = customFilter.predefined_search_predicate || {};
         // @ts-ignore
         urlData.predefined_search_chip = customFilter.predefined_search_chip || null;
@@ -1193,7 +1196,7 @@ export const SolidKanbanView = forwardRef<SolidKanbanViewHandle, SolidKanbanView
                     `lg:flex`. Only media-scoped visibility classes are safe on this element. */}
                 <div className={`${showGlobalSearchElement ? "flex" : "max-lg:hidden lg:flex"} w-full mt-3 lg:mt-0 lg:min-w-0`}>
                   {/* Keep global search mounted for now because kanban bootstrap/filter hydration still flows through this element. */}
-                  <SolidGlobalSearchElement viewType="kanban" showSaveFilterPopup={showSaveFilterPopup} setShowSaveFilterPopup={setShowSaveFilterPopup} ref={solidGlobalSearchElementRef} viewData={solidKanbanViewMetaData} handleApplyCustomFilter={handleApplyCustomFilter} filterPredicates={filterPredicates} ></SolidGlobalSearchElement>
+                  <SolidGlobalSearchElement viewType="kanban" showSaveFilterPopup={showSaveFilterPopup} setShowSaveFilterPopup={setShowSaveFilterPopup} ref={solidGlobalSearchElementRef} viewData={solidKanbanViewMetaData} handleApplyCustomFilter={handleApplyCustomFilter} filterPredicates={filterPredicates} allowMultipleSavedFilters></SolidGlobalSearchElement>
                 </div>
               </div>
 

--- a/src/components/core/list/SolidListView.tsx
+++ b/src/components/core/list/SolidListView.tsx
@@ -105,6 +105,7 @@ export type SolidListViewHandle = {
     custom_filter_predicate?: any;
     search_predicate?: any;
     saved_filter_predicate?: any;
+    saved_filter_items?: any[];
     predefined_search_predicate?: any;
   }) => void;
   /**
@@ -887,6 +888,7 @@ export const SolidListView = forwardRef<SolidListViewHandle, SolidListViewParams
       fileterTobeStored.saved_filter_id = latestFilterPredicatesRef.current.saved_filter_id || null;
       fileterTobeStored.saved_filter_system_key = latestFilterPredicatesRef.current.saved_filter_system_key || null;
       fileterTobeStored.saved_filter_name = latestFilterPredicatesRef.current.saved_filter_name || null;
+      fileterTobeStored.saved_filter_items = latestFilterPredicatesRef.current.saved_filter_items || [];
       fileterTobeStored.predefined_search_predicate = latestFilterPredicatesRef.current.predefined_search_predicate || null;
       fileterTobeStored.predefined_search_chip = latestFilterPredicatesRef.current.predefined_search_chip || null;
       setFilterObjectToLocalStorage(fileterTobeStored);
@@ -1440,6 +1442,7 @@ export const SolidListView = forwardRef<SolidListViewHandle, SolidListViewParams
                           viewData={solidListViewMetaData}
                           handleApplyCustomFilter={handleApplyCustomFilter}
                           filterPredicates={filterPredicates}
+                          allowMultipleSavedFilters
                         >
                         </SolidGlobalSearchElement>
                       </div>

--- a/src/components/core/tree/SolidTreeView.tsx
+++ b/src/components/core/tree/SolidTreeView.tsx
@@ -68,8 +68,11 @@ export type SolidTreeViewHandle = {
     custom_filter_predicate?: any;
     search_predicate?: any;
     saved_filter_predicate?: any;
+    saved_filter_items?: any[];
     predefined_search_predicate?: any;
   }) => void;
+  getSavedFilters: () => any[];
+  applySavedFilter: (name: string, variables?: Record<string, any>) => boolean;
   setPagination: (nextFirst: number, nextRows: number) => void;
   setSort: (nextSortField: string, nextSortOrder: 1 | -1 | 0) => void;
   setShowArchived: (value: boolean) => void;
@@ -1069,6 +1072,10 @@ export const SolidTreeView = forwardRef<SolidTreeViewHandle, SolidTreeViewParams
           search_predicate: latestFilterPredicatesRef.current.search_predicate || null,
           saved_filter_predicate: latestFilterPredicatesRef.current.saved_filter_predicate || null,
           saved_filter_variables: latestFilterPredicatesRef.current.saved_filter_variables || {},
+          saved_filter_id: latestFilterPredicatesRef.current.saved_filter_id || null,
+          saved_filter_system_key: latestFilterPredicatesRef.current.saved_filter_system_key || null,
+          saved_filter_name: latestFilterPredicatesRef.current.saved_filter_name || null,
+          saved_filter_items: latestFilterPredicatesRef.current.saved_filter_items || [],
           predefined_search_predicate: latestFilterPredicatesRef.current.predefined_search_predicate || null,
           grouping_rules: latestFilterPredicatesRef.current.grouping_rules || null,
           aggregation_rules: latestFilterPredicatesRef.current.aggregation_rules || null,
@@ -1561,6 +1568,8 @@ export const SolidTreeView = forwardRef<SolidTreeViewHandle, SolidTreeViewParams
       solidGlobalSearchElementRef.current?.clearFilter?.();
     },
     applyFilter: (filter) => { handleApplyCustomFilter(filter); },
+    getSavedFilters: () => solidGlobalSearchElementRef.current?.getSavedFilters?.() ?? [],
+    applySavedFilter: (name, variables) => solidGlobalSearchElementRef.current?.applySavedFilterByName?.(name, variables) ?? false,
     setPagination: (nextFirst: number, nextRows: number) => {
       const currentLimit = getPagination("root").limit;
       if (nextRows !== currentLimit) {
@@ -1921,6 +1930,7 @@ export const SolidTreeView = forwardRef<SolidTreeViewHandle, SolidTreeViewParams
                         viewData={solidTreeViewMetaData}
                         handleApplyCustomFilter={handleApplyCustomFilter}
                         filterPredicates={filterPredicates}
+                        allowMultipleSavedFilters
                       />
                     </div>
                   </>


### PR DESCRIPTION
Re-applies the multiple-saved-filters feature from #210, which was reverted in #211 (commit `1510f0fe`).

GitHub's "Revert" button on #211 could not do this automatically because `SolidGlobalSearchElement.tsx` was edited after the revert landed. Done locally with `git revert 1510f0fe`, which 3-way merges and only conflicted in two spots.

### Conflict resolution
Both conflicts were in `SolidGlobalSearchElement.tsx`, against #218 (saved-filter toasts):

- **Component signature** — kept the `allowMultipleSavedFilters = false` prop from #210 and the `const dispatch = useDispatch()` from #218.
- **`deleteSavedFilter`** — kept #218's `try/catch` with success and error toasts, and moved #210's `allowMultipleSavedFilters` branch inside the `try` so both toasts still fire.

`handleSaveFilter` auto-merged and retains the toasts alongside the multi-filter guards. `SolidListView.tsx` merged with no conflict; `423b837a`'s `column.attrs.label ?? column.attrs.name ?? …` fallback is preserved.

### Verification
- `git diff d914fe18 HEAD` over both files shows **only** the #218 toast deltas and the `423b837a` one-liner — no feature logic was lost in the resolution.
- `npx tsc -p tsconfig.json --noEmit` passes clean.

Still worth a manual pass on: applying two saved filters at once, rename/create/delete toasts, and an induced API failure showing the error toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)